### PR TITLE
Clarify combined race scores on athlete pages

### DIFF
--- a/docs/athletes/al-de-sousa-costain_summary.html
+++ b/docs/athletes/al-de-sousa-costain_summary.html
@@ -27,7 +27,7 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../races/manchester-half-marathon_summary.html">Manchester Half Marathon*</a></td>
@@ -38,8 +38,27 @@
     <td>15</td>
     <td>34</td>
 </tr>
+<tr>
+    <td><a href="../races/combined-5k-leaderboard_summary.html">Best 5k*</a></td>
+    <td>29/08/2025</td>
+    <td>19:48</td>
+    <td>67.76</td>
+    <td>3</td>
+    <td>0</td>
+    <td>3</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>22</td>
+    <td>15</td>
+    <td>37</td>
+</tr>
 </table>
 <h2>5k races</h2>
+<p>5k races are not scored individually. Instead, your fastest time contributes to the <a href="../races/combined-5k-leaderboard_summary.html">best 5k leaderboard</a>, which is then scored as if it were a single race.</p>
 <table>
 <caption>* denotes race contributes to athlete's total score</caption>
 <tr>
@@ -47,45 +66,30 @@
     <th>Date</th>
     <th>Time</th>
     <th>Age %</th>
-    <th>Time score</th>
-    <th>Age % score</th>
-    <th>Total score</th>
 </tr>
 <tr>
     <td><a href="../races/sale-sizzler-1_summary.html">Sale sizzler 1</a></td>
     <td>19/06/2025</td>
     <td>20:38</td>
     <td>65.02</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
 </tr>
 <tr>
     <td><a href="../races/sale-sizzler-2_summary.html">Sale sizzler 2</a></td>
     <td>04/07/2025</td>
     <td>20:15</td>
     <td>66.26</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
 </tr>
 <tr>
     <td><a href="../races/sale-sizzler-4_summary.html">Sale sizzler 4</a></td>
     <td>31/07/2025</td>
     <td>20:07</td>
     <td>66.69</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
 </tr>
 <tr>
     <td><a href="../races/mid-cheshire-summer-5k_summary.html">Mid-Cheshire Summer 5k*</a></td>
     <td>29/08/2025</td>
     <td>19:48</td>
     <td>67.76</td>
-    <td>3</td>
-    <td>0</td>
-    <td>3</td>
 </tr>
 </table>
 <h2>Marathons</h2>

--- a/docs/athletes/alana-dunn_summary.html
+++ b/docs/athletes/alana-dunn_summary.html
@@ -18,8 +18,6 @@
     <li>Category position: 5 out of 8</li>
 </ul>
 <h2>Club races</h2>
-None
-<h2>5k races</h2>
 <table>
 <caption>* denotes race contributes to athlete's total score</caption>
 <tr>
@@ -29,16 +27,42 @@ None
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
-    <td><a href="../races/sale-sizzler-4_summary.html">Sale sizzler 4*</a></td>
+    <td><a href="../races/combined-5k-leaderboard_summary.html">Best 5k*</a></td>
     <td>31/07/2025</td>
     <td>19:23</td>
     <td>76.18</td>
     <td>23</td>
     <td>2</td>
     <td>25</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>23</td>
+    <td>2</td>
+    <td>25</td>
+</tr>
+</table>
+<h2>5k races</h2>
+<p>5k races are not scored individually. Instead, your fastest time contributes to the <a href="../races/combined-5k-leaderboard_summary.html">best 5k leaderboard</a>, which is then scored as if it were a single race.</p>
+<table>
+<caption>* denotes race contributes to athlete's total score</caption>
+<tr>
+    <th>Race</th>
+    <th>Date</th>
+    <th>Time</th>
+    <th>Age %</th>
+</tr>
+<tr>
+    <td><a href="../races/sale-sizzler-4_summary.html">Sale sizzler 4*</a></td>
+    <td>31/07/2025</td>
+    <td>19:23</td>
+    <td>76.18</td>
 </tr>
 </table>
 <h2>Marathons</h2>

--- a/docs/athletes/andrew-paton-crockett_summary.html
+++ b/docs/athletes/andrew-paton-crockett_summary.html
@@ -27,13 +27,22 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../races/altrincham-10k_summary.html">Altrincham 10k*</a></td>
     <td>07/09/2025</td>
     <td>45:06</td>
     <td>61.94</td>
+    <td>11</td>
+    <td>4</td>
+    <td>15</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td>11</td>
     <td>4</td>
     <td>15</td>

--- a/docs/athletes/andrew-pickford_summary.html
+++ b/docs/athletes/andrew-pickford_summary.html
@@ -27,7 +27,7 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../races/altrincham-10k_summary.html">Altrincham 10k*</a></td>
@@ -38,8 +38,27 @@
     <td>8</td>
     <td>16</td>
 </tr>
+<tr>
+    <td><a href="../races/combined-5k-leaderboard_summary.html">Best 5k*</a></td>
+    <td>19/06/2025</td>
+    <td>18:31</td>
+    <td>80.29</td>
+    <td>9</td>
+    <td>11</td>
+    <td>20</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>17</td>
+    <td>19</td>
+    <td>36</td>
+</tr>
 </table>
 <h2>5k races</h2>
+<p>5k races are not scored individually. Instead, your fastest time contributes to the <a href="../races/combined-5k-leaderboard_summary.html">best 5k leaderboard</a>, which is then scored as if it were a single race.</p>
 <table>
 <caption>* denotes race contributes to athlete's total score</caption>
 <tr>
@@ -47,18 +66,12 @@
     <th>Date</th>
     <th>Time</th>
     <th>Age %</th>
-    <th>Time score</th>
-    <th>Age % score</th>
-    <th>Total score</th>
 </tr>
 <tr>
     <td><a href="../races/sale-sizzler-1_summary.html">Sale sizzler 1*</a></td>
     <td>19/06/2025</td>
     <td>18:31</td>
     <td>80.29</td>
-    <td>9</td>
-    <td>11</td>
-    <td>20</td>
 </tr>
 </table>
 <h2>Marathons</h2>

--- a/docs/athletes/annabel-dickinson_summary.html
+++ b/docs/athletes/annabel-dickinson_summary.html
@@ -27,7 +27,7 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../races/wilmslow-summer-10k_summary.html">Wilmslow Summer 10k*</a></td>
@@ -47,8 +47,27 @@
     <td>1</td>
     <td>23</td>
 </tr>
+<tr>
+    <td><a href="../races/combined-5k-leaderboard_summary.html">Best 5k*</a></td>
+    <td>05/06/2025</td>
+    <td>25:43</td>
+    <td>57.42</td>
+    <td>17</td>
+    <td>0</td>
+    <td>17</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>62</td>
+    <td>14</td>
+    <td>76</td>
+</tr>
 </table>
 <h2>5k races</h2>
+<p>5k races are not scored individually. Instead, your fastest time contributes to the <a href="../races/combined-5k-leaderboard_summary.html">best 5k leaderboard</a>, which is then scored as if it were a single race.</p>
 <table>
 <caption>* denotes race contributes to athlete's total score</caption>
 <tr>
@@ -56,18 +75,12 @@
     <th>Date</th>
     <th>Time</th>
     <th>Age %</th>
-    <th>Time score</th>
-    <th>Age % score</th>
-    <th>Total score</th>
 </tr>
 <tr>
     <td><a href="../races/dunham-massey-5k-june_summary.html">Dunham Massey 5k June*</a></td>
     <td>05/06/2025</td>
     <td>25:43</td>
     <td>57.42</td>
-    <td>17</td>
-    <td>0</td>
-    <td>17</td>
 </tr>
 </table>
 <h2>Marathons</h2>

--- a/docs/athletes/becky-hansen_summary.html
+++ b/docs/athletes/becky-hansen_summary.html
@@ -27,7 +27,7 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../races/altrincham-10k_summary.html">Altrincham 10k*</a></td>
@@ -47,8 +47,27 @@
     <td>24</td>
     <td>49</td>
 </tr>
+<tr>
+    <td><a href="../races/combined-5k-leaderboard_summary.html">Best 5k*</a></td>
+    <td>04/07/2025</td>
+    <td>18:10</td>
+    <td>82.66</td>
+    <td>25</td>
+    <td>17</td>
+    <td>42</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>75</td>
+    <td>65</td>
+    <td>140</td>
+</tr>
 </table>
 <h2>5k races</h2>
+<p>5k races are not scored individually. Instead, your fastest time contributes to the <a href="../races/combined-5k-leaderboard_summary.html">best 5k leaderboard</a>, which is then scored as if it were a single race.</p>
 <table>
 <caption>* denotes race contributes to athlete's total score</caption>
 <tr>
@@ -56,27 +75,18 @@
     <th>Date</th>
     <th>Time</th>
     <th>Age %</th>
-    <th>Time score</th>
-    <th>Age % score</th>
-    <th>Total score</th>
 </tr>
 <tr>
     <td><a href="../races/dunham-massey-5k-june_summary.html">Dunham Massey 5k June</a></td>
     <td>05/06/2025</td>
     <td>18:25</td>
     <td>81.54</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
 </tr>
 <tr>
     <td><a href="../races/sale-sizzler-2_summary.html">Sale sizzler 2*</a></td>
     <td>04/07/2025</td>
     <td>18:10</td>
     <td>82.66</td>
-    <td>25</td>
-    <td>17</td>
-    <td>42</td>
 </tr>
 </table>
 <h2>Marathons</h2>

--- a/docs/athletes/ben-walmsley_summary.html
+++ b/docs/athletes/ben-walmsley_summary.html
@@ -18,8 +18,6 @@
     <li>Category position: 6 out of 16</li>
 </ul>
 <h2>Club races</h2>
-None
-<h2>5k races</h2>
 <table>
 <caption>* denotes race contributes to athlete's total score</caption>
 <tr>
@@ -29,43 +27,60 @@ None
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
-    <td><a href="../races/dunham-massey-5k-june_summary.html">Dunham Massey 5k June</a></td>
-    <td>05/06/2025</td>
-    <td>16:41</td>
-    <td>82.22</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
-</tr>
-<tr>
-    <td><a href="../races/sale-sizzler-4_summary.html">Sale sizzler 4</a></td>
-    <td>31/07/2025</td>
-    <td>16:32</td>
-    <td>82.96</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
-</tr>
-<tr>
-    <td><a href="../races/ellesmere-port-5k_summary.html">Ellesmere port 5k</a></td>
-    <td>13/08/2025</td>
-    <td>16:24</td>
-    <td>83.64</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
-</tr>
-<tr>
-    <td><a href="../races/mid-cheshire-summer-5k_summary.html">Mid-Cheshire Summer 5k*</a></td>
+    <td><a href="../races/combined-5k-leaderboard_summary.html">Best 5k*</a></td>
     <td>29/08/2025</td>
     <td>16:21</td>
     <td>83.89</td>
     <td>23</td>
     <td>21</td>
     <td>44</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>23</td>
+    <td>21</td>
+    <td>44</td>
+</tr>
+</table>
+<h2>5k races</h2>
+<p>5k races are not scored individually. Instead, your fastest time contributes to the <a href="../races/combined-5k-leaderboard_summary.html">best 5k leaderboard</a>, which is then scored as if it were a single race.</p>
+<table>
+<caption>* denotes race contributes to athlete's total score</caption>
+<tr>
+    <th>Race</th>
+    <th>Date</th>
+    <th>Time</th>
+    <th>Age %</th>
+</tr>
+<tr>
+    <td><a href="../races/dunham-massey-5k-june_summary.html">Dunham Massey 5k June</a></td>
+    <td>05/06/2025</td>
+    <td>16:41</td>
+    <td>82.22</td>
+</tr>
+<tr>
+    <td><a href="../races/sale-sizzler-4_summary.html">Sale sizzler 4</a></td>
+    <td>31/07/2025</td>
+    <td>16:32</td>
+    <td>82.96</td>
+</tr>
+<tr>
+    <td><a href="../races/ellesmere-port-5k_summary.html">Ellesmere port 5k</a></td>
+    <td>13/08/2025</td>
+    <td>16:24</td>
+    <td>83.64</td>
+</tr>
+<tr>
+    <td><a href="../races/mid-cheshire-summer-5k_summary.html">Mid-Cheshire Summer 5k*</a></td>
+    <td>29/08/2025</td>
+    <td>16:21</td>
+    <td>83.89</td>
 </tr>
 </table>
 <h2>Marathons</h2>

--- a/docs/athletes/beverley-jackson_summary.html
+++ b/docs/athletes/beverley-jackson_summary.html
@@ -18,8 +18,6 @@
     <li>Category position: 1 out of 2</li>
 </ul>
 <h2>Club races</h2>
-None
-<h2>5k races</h2>
 <table>
 <caption>* denotes race contributes to athlete's total score</caption>
 <tr>
@@ -29,19 +27,10 @@ None
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
-    <td><a href="../races/sale-sizzler-1_summary.html">Sale sizzler 1</a></td>
-    <td>19/06/2025</td>
-    <td>23:37</td>
-    <td>79.46</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
-</tr>
-<tr>
-    <td><a href="../races/sale-sizzler-4_summary.html">Sale sizzler 4*</a></td>
+    <td><a href="../races/combined-5k-leaderboard_summary.html">Best 5k*</a></td>
     <td>31/07/2025</td>
     <td>22:38</td>
     <td>82.92</td>
@@ -50,13 +39,42 @@ None
     <td>38</td>
 </tr>
 <tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>20</td>
+    <td>18</td>
+    <td>38</td>
+</tr>
+</table>
+<h2>5k races</h2>
+<p>5k races are not scored individually. Instead, your fastest time contributes to the <a href="../races/combined-5k-leaderboard_summary.html">best 5k leaderboard</a>, which is then scored as if it were a single race.</p>
+<table>
+<caption>* denotes race contributes to athlete's total score</caption>
+<tr>
+    <th>Race</th>
+    <th>Date</th>
+    <th>Time</th>
+    <th>Age %</th>
+</tr>
+<tr>
+    <td><a href="../races/sale-sizzler-1_summary.html">Sale sizzler 1</a></td>
+    <td>19/06/2025</td>
+    <td>23:37</td>
+    <td>79.46</td>
+</tr>
+<tr>
+    <td><a href="../races/sale-sizzler-4_summary.html">Sale sizzler 4*</a></td>
+    <td>31/07/2025</td>
+    <td>22:38</td>
+    <td>82.92</td>
+</tr>
+<tr>
     <td><a href="../races/mid-cheshire-summer-5k_summary.html">Mid-Cheshire Summer 5k</a></td>
     <td>29/08/2025</td>
     <td>22:45</td>
     <td>82.49</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
 </tr>
 </table>
 <h2>Marathons</h2>

--- a/docs/athletes/colin-davies_summary.html
+++ b/docs/athletes/colin-davies_summary.html
@@ -27,13 +27,22 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../races/altrincham-10k_summary.html">Altrincham 10k*</a></td>
     <td>07/09/2025</td>
     <td>59:01</td>
     <td>65.69</td>
+    <td>3</td>
+    <td>7</td>
+    <td>10</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td>3</td>
     <td>7</td>
     <td>10</td>

--- a/docs/athletes/craig-foster_summary.html
+++ b/docs/athletes/craig-foster_summary.html
@@ -27,7 +27,7 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../races/wizard-5_summary.html">Wizard 5*</a></td>
@@ -38,8 +38,27 @@
     <td>22</td>
     <td>45</td>
 </tr>
+<tr>
+    <td><a href="../races/combined-5k-leaderboard_summary.html">Best 5k*</a></td>
+    <td>05/06/2025</td>
+    <td>19:46</td>
+    <td>70.83</td>
+    <td>4</td>
+    <td>0</td>
+    <td>4</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>27</td>
+    <td>22</td>
+    <td>49</td>
+</tr>
 </table>
 <h2>5k races</h2>
+<p>5k races are not scored individually. Instead, your fastest time contributes to the <a href="../races/combined-5k-leaderboard_summary.html">best 5k leaderboard</a>, which is then scored as if it were a single race.</p>
 <table>
 <caption>* denotes race contributes to athlete's total score</caption>
 <tr>
@@ -47,18 +66,12 @@
     <th>Date</th>
     <th>Time</th>
     <th>Age %</th>
-    <th>Time score</th>
-    <th>Age % score</th>
-    <th>Total score</th>
 </tr>
 <tr>
     <td><a href="../races/dunham-massey-5k-june_summary.html">Dunham Massey 5k June*</a></td>
     <td>05/06/2025</td>
     <td>19:46</td>
     <td>70.83</td>
-    <td>4</td>
-    <td>0</td>
-    <td>4</td>
 </tr>
 </table>
 <h2>Marathons</h2>

--- a/docs/athletes/damian-utton_summary.html
+++ b/docs/athletes/damian-utton_summary.html
@@ -27,7 +27,7 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../races/wilmslow-summer-10k_summary.html">Wilmslow Summer 10k*</a></td>
@@ -47,8 +47,27 @@
     <td>9</td>
     <td>15</td>
 </tr>
+<tr>
+    <td><a href="../races/combined-5k-leaderboard_summary.html">Best 5k*</a></td>
+    <td>31/07/2025</td>
+    <td>23:42</td>
+    <td>67.93</td>
+    <td>0</td>
+    <td>0</td>
+    <td>0</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>22</td>
+    <td>26</td>
+    <td>48</td>
+</tr>
 </table>
 <h2>5k races</h2>
+<p>5k races are not scored individually. Instead, your fastest time contributes to the <a href="../races/combined-5k-leaderboard_summary.html">best 5k leaderboard</a>, which is then scored as if it were a single race.</p>
 <table>
 <caption>* denotes race contributes to athlete's total score</caption>
 <tr>
@@ -56,27 +75,18 @@
     <th>Date</th>
     <th>Time</th>
     <th>Age %</th>
-    <th>Time score</th>
-    <th>Age % score</th>
-    <th>Total score</th>
 </tr>
 <tr>
     <td><a href="../races/sale-sizzler-1_summary.html">Sale sizzler 1</a></td>
     <td>19/06/2025</td>
     <td>24:05</td>
     <td>66.85</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
 </tr>
 <tr>
     <td><a href="../races/sale-sizzler-4_summary.html">Sale sizzler 4*</a></td>
     <td>31/07/2025</td>
     <td>23:42</td>
     <td>67.93</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
 </tr>
 </table>
 <h2>Marathons</h2>

--- a/docs/athletes/dan-martell_summary.html
+++ b/docs/athletes/dan-martell_summary.html
@@ -18,8 +18,6 @@
     <li>Category position: 7 out of 10</li>
 </ul>
 <h2>Club races</h2>
-None
-<h2>5k races</h2>
 <table>
 <caption>* denotes race contributes to athlete's total score</caption>
 <tr>
@@ -29,16 +27,42 @@ None
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
-    <td><a href="../races/sale-sizzler-4_summary.html">Sale sizzler 4*</a></td>
+    <td><a href="../races/combined-5k-leaderboard_summary.html">Best 5k*</a></td>
     <td>31/07/2025</td>
     <td>18:19</td>
     <td>72.79</td>
     <td>11</td>
     <td>0</td>
     <td>11</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>11</td>
+    <td>0</td>
+    <td>11</td>
+</tr>
+</table>
+<h2>5k races</h2>
+<p>5k races are not scored individually. Instead, your fastest time contributes to the <a href="../races/combined-5k-leaderboard_summary.html">best 5k leaderboard</a>, which is then scored as if it were a single race.</p>
+<table>
+<caption>* denotes race contributes to athlete's total score</caption>
+<tr>
+    <th>Race</th>
+    <th>Date</th>
+    <th>Time</th>
+    <th>Age %</th>
+</tr>
+<tr>
+    <td><a href="../races/sale-sizzler-4_summary.html">Sale sizzler 4*</a></td>
+    <td>31/07/2025</td>
+    <td>18:19</td>
+    <td>72.79</td>
 </tr>
 </table>
 <h2>Marathons</h2>

--- a/docs/athletes/darren-martin_summary.html
+++ b/docs/athletes/darren-martin_summary.html
@@ -27,13 +27,22 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../races/manchester-half-marathon_summary.html">Manchester Half Marathon*</a></td>
     <td>12/10/2025</td>
     <td>1:59:03</td>
     <td>57.22</td>
+    <td>16</td>
+    <td>12</td>
+    <td>28</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td>16</td>
     <td>12</td>
     <td>28</td>

--- a/docs/athletes/david-ainsworth_summary.html
+++ b/docs/athletes/david-ainsworth_summary.html
@@ -27,7 +27,7 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../races/wilmslow-summer-10k_summary.html">Wilmslow Summer 10k*</a></td>
@@ -38,8 +38,27 @@
     <td>25</td>
     <td>44</td>
 </tr>
+<tr>
+    <td><a href="../races/combined-5k-leaderboard_summary.html">Best 5k*</a></td>
+    <td>29/08/2025</td>
+    <td>19:59</td>
+    <td>84.07</td>
+    <td>0</td>
+    <td>22</td>
+    <td>22</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>19</td>
+    <td>47</td>
+    <td>66</td>
+</tr>
 </table>
 <h2>5k races</h2>
+<p>5k races are not scored individually. Instead, your fastest time contributes to the <a href="../races/combined-5k-leaderboard_summary.html">best 5k leaderboard</a>, which is then scored as if it were a single race.</p>
 <table>
 <caption>* denotes race contributes to athlete's total score</caption>
 <tr>
@@ -47,36 +66,24 @@
     <th>Date</th>
     <th>Time</th>
     <th>Age %</th>
-    <th>Time score</th>
-    <th>Age % score</th>
-    <th>Total score</th>
 </tr>
 <tr>
     <td><a href="../races/sale-sizzler-1_summary.html">Sale sizzler 1</a></td>
     <td>19/06/2025</td>
     <td>20:36</td>
     <td>81.55</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
 </tr>
 <tr>
     <td><a href="../races/sale-sizzler-3_summary.html">Sale sizzler 3</a></td>
     <td>18/07/2025</td>
     <td>20:30</td>
     <td>81.95</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
 </tr>
 <tr>
     <td><a href="../races/mid-cheshire-summer-5k_summary.html">Mid-Cheshire Summer 5k*</a></td>
     <td>29/08/2025</td>
     <td>19:59</td>
     <td>84.07</td>
-    <td>0</td>
-    <td>22</td>
-    <td>22</td>
 </tr>
 </table>
 <h2>Marathons</h2>

--- a/docs/athletes/david-norman_summary.html
+++ b/docs/athletes/david-norman_summary.html
@@ -27,7 +27,7 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../races/wilmslow-summer-10k_summary.html">Wilmslow Summer 10k*</a></td>
@@ -38,8 +38,27 @@
     <td>19</td>
     <td>39</td>
 </tr>
+<tr>
+    <td><a href="../races/combined-5k-leaderboard_summary.html">Best 5k*</a></td>
+    <td>05/09/2025</td>
+    <td>16:27</td>
+    <td>87.03</td>
+    <td>22</td>
+    <td>23</td>
+    <td>45</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>42</td>
+    <td>42</td>
+    <td>84</td>
+</tr>
 </table>
 <h2>5k races</h2>
+<p>5k races are not scored individually. Instead, your fastest time contributes to the <a href="../races/combined-5k-leaderboard_summary.html">best 5k leaderboard</a>, which is then scored as if it were a single race.</p>
 <table>
 <caption>* denotes race contributes to athlete's total score</caption>
 <tr>
@@ -47,18 +66,12 @@
     <th>Date</th>
     <th>Time</th>
     <th>Age %</th>
-    <th>Time score</th>
-    <th>Age % score</th>
-    <th>Total score</th>
 </tr>
 <tr>
     <td><a href="../races/tameside-september-5k_summary.html">Tameside September 5k*</a></td>
     <td>05/09/2025</td>
     <td>16:27</td>
     <td>87.03</td>
-    <td>22</td>
-    <td>23</td>
-    <td>45</td>
 </tr>
 </table>
 <h2>Marathons</h2>

--- a/docs/athletes/dominic-renshaw_summary.html
+++ b/docs/athletes/dominic-renshaw_summary.html
@@ -27,7 +27,7 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../races/altrincham-10k_summary.html">Altrincham 10k*</a></td>
@@ -38,8 +38,27 @@
     <td>12</td>
     <td>29</td>
 </tr>
+<tr>
+    <td><a href="../races/combined-5k-leaderboard_summary.html">Best 5k*</a></td>
+    <td>29/08/2025</td>
+    <td>18:27</td>
+    <td>74.80</td>
+    <td>10</td>
+    <td>1</td>
+    <td>11</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>27</td>
+    <td>13</td>
+    <td>40</td>
+</tr>
 </table>
 <h2>5k races</h2>
+<p>5k races are not scored individually. Instead, your fastest time contributes to the <a href="../races/combined-5k-leaderboard_summary.html">best 5k leaderboard</a>, which is then scored as if it were a single race.</p>
 <table>
 <caption>* denotes race contributes to athlete's total score</caption>
 <tr>
@@ -47,36 +66,24 @@
     <th>Date</th>
     <th>Time</th>
     <th>Age %</th>
-    <th>Time score</th>
-    <th>Age % score</th>
-    <th>Total score</th>
 </tr>
 <tr>
     <td><a href="../races/sale-sizzler-3_summary.html">Sale sizzler 3</a></td>
     <td>18/07/2025</td>
     <td>18:52</td>
     <td>73.14</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
 </tr>
 <tr>
     <td><a href="../races/sale-sizzler-4_summary.html">Sale sizzler 4</a></td>
     <td>31/07/2025</td>
     <td>18:47</td>
     <td>73.47</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
 </tr>
 <tr>
     <td><a href="../races/mid-cheshire-summer-5k_summary.html">Mid-Cheshire Summer 5k*</a></td>
     <td>29/08/2025</td>
     <td>18:27</td>
     <td>74.80</td>
-    <td>10</td>
-    <td>1</td>
-    <td>11</td>
 </tr>
 </table>
 <h2>Marathons</h2>

--- a/docs/athletes/duncan-dickinson_summary.html
+++ b/docs/athletes/duncan-dickinson_summary.html
@@ -27,7 +27,7 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../races/altrincham-10k_summary.html">Altrincham 10k*</a></td>
@@ -47,21 +47,8 @@
     <td>19</td>
     <td>36</td>
 </tr>
-</table>
-<h2>5k races</h2>
-<table>
-<caption>* denotes race contributes to athlete's total score</caption>
 <tr>
-    <th>Race</th>
-    <th>Date</th>
-    <th>Time</th>
-    <th>Age %</th>
-    <th>Time score</th>
-    <th>Age % score</th>
-    <th>Total score</th>
-</tr>
-<tr>
-    <td><a href="../races/sale-sizzler-1_summary.html">Sale sizzler 1*</a></td>
+    <td><a href="../races/combined-5k-leaderboard_summary.html">Best 5k*</a></td>
     <td>19/06/2025</td>
     <td>21:40</td>
     <td>73.69</td>
@@ -70,22 +57,42 @@
     <td>0</td>
 </tr>
 <tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>27</td>
+    <td>33</td>
+    <td>60</td>
+</tr>
+</table>
+<h2>5k races</h2>
+<p>5k races are not scored individually. Instead, your fastest time contributes to the <a href="../races/combined-5k-leaderboard_summary.html">best 5k leaderboard</a>, which is then scored as if it were a single race.</p>
+<table>
+<caption>* denotes race contributes to athlete's total score</caption>
+<tr>
+    <th>Race</th>
+    <th>Date</th>
+    <th>Time</th>
+    <th>Age %</th>
+</tr>
+<tr>
+    <td><a href="../races/sale-sizzler-1_summary.html">Sale sizzler 1*</a></td>
+    <td>19/06/2025</td>
+    <td>21:40</td>
+    <td>73.69</td>
+</tr>
+<tr>
     <td><a href="../races/sale-sizzler-3_summary.html">Sale sizzler 3</a></td>
     <td>18/07/2025</td>
     <td>21:57</td>
     <td>72.74</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
 </tr>
 <tr>
     <td><a href="../races/mid-cheshire-summer-5k_summary.html">Mid-Cheshire Summer 5k</a></td>
     <td>29/08/2025</td>
     <td>22:04</td>
     <td>72.36</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
 </tr>
 </table>
 <h2>Marathons</h2>

--- a/docs/athletes/dylan-marodeen_summary.html
+++ b/docs/athletes/dylan-marodeen_summary.html
@@ -27,13 +27,22 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../races/manchester-half-marathon_summary.html">Manchester Half Marathon*</a></td>
     <td>12/10/2025</td>
     <td>1:32:34</td>
     <td>63.07</td>
+    <td>18</td>
+    <td>14</td>
+    <td>32</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td>18</td>
     <td>14</td>
     <td>32</td>

--- a/docs/athletes/frazer-cowgill_summary.html
+++ b/docs/athletes/frazer-cowgill_summary.html
@@ -27,13 +27,22 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../races/altrincham-10k_summary.html">Altrincham 10k*</a></td>
     <td>07/09/2025</td>
     <td>53:06</td>
     <td>50.41</td>
+    <td>5</td>
+    <td>0</td>
+    <td>5</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td>5</td>
     <td>0</td>
     <td>5</td>

--- a/docs/athletes/gordon-nicoll_summary.html
+++ b/docs/athletes/gordon-nicoll_summary.html
@@ -27,7 +27,7 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../races/altrincham-10k_summary.html">Altrincham 10k*</a></td>
@@ -38,8 +38,27 @@
     <td>23</td>
     <td>39</td>
 </tr>
+<tr>
+    <td><a href="../races/combined-5k-leaderboard_summary.html">Best 5k*</a></td>
+    <td>29/08/2025</td>
+    <td>19:34</td>
+    <td>82.96</td>
+    <td>6</td>
+    <td>20</td>
+    <td>26</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>22</td>
+    <td>43</td>
+    <td>65</td>
+</tr>
 </table>
 <h2>5k races</h2>
+<p>5k races are not scored individually. Instead, your fastest time contributes to the <a href="../races/combined-5k-leaderboard_summary.html">best 5k leaderboard</a>, which is then scored as if it were a single race.</p>
 <table>
 <caption>* denotes race contributes to athlete's total score</caption>
 <tr>
@@ -47,45 +66,30 @@
     <th>Date</th>
     <th>Time</th>
     <th>Age %</th>
-    <th>Time score</th>
-    <th>Age % score</th>
-    <th>Total score</th>
 </tr>
 <tr>
     <td><a href="../races/sale-sizzler-1_summary.html">Sale sizzler 1</a></td>
     <td>19/06/2025</td>
     <td>20:31</td>
     <td>79.12</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
 </tr>
 <tr>
     <td><a href="../races/sale-sizzler-3_summary.html">Sale sizzler 3</a></td>
     <td>18/07/2025</td>
     <td>20:06</td>
     <td>80.76</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
 </tr>
 <tr>
     <td><a href="../races/sale-sizzler-4_summary.html">Sale sizzler 4</a></td>
     <td>31/07/2025</td>
     <td>20:34</td>
     <td>78.93</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
 </tr>
 <tr>
     <td><a href="../races/mid-cheshire-summer-5k_summary.html">Mid-Cheshire Summer 5k*</a></td>
     <td>29/08/2025</td>
     <td>19:34</td>
     <td>82.96</td>
-    <td>6</td>
-    <td>20</td>
-    <td>26</td>
 </tr>
 </table>
 <h2>Marathons</h2>

--- a/docs/athletes/graham-harrison_summary.html
+++ b/docs/athletes/graham-harrison_summary.html
@@ -18,8 +18,6 @@
     <li>Category position: 2 out of 5</li>
 </ul>
 <h2>Club races</h2>
-None
-<h2>5k races</h2>
 <table>
 <caption>* denotes race contributes to athlete's total score</caption>
 <tr>
@@ -29,34 +27,54 @@ None
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
-    <td><a href="../races/sale-sizzler-2_summary.html">Sale sizzler 2</a></td>
-    <td>04/07/2025</td>
-    <td>21:58</td>
-    <td>75.19</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
-</tr>
-<tr>
-    <td><a href="../races/sale-sizzler-4_summary.html">Sale sizzler 4</a></td>
-    <td>31/07/2025</td>
-    <td>21:39</td>
-    <td>76.29</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
-</tr>
-<tr>
-    <td><a href="../races/mid-cheshire-summer-5k_summary.html">Mid-Cheshire Summer 5k*</a></td>
+    <td><a href="../races/combined-5k-leaderboard_summary.html">Best 5k*</a></td>
     <td>29/08/2025</td>
     <td>21:17</td>
     <td>77.60</td>
     <td>0</td>
     <td>7</td>
     <td>7</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>0</td>
+    <td>7</td>
+    <td>7</td>
+</tr>
+</table>
+<h2>5k races</h2>
+<p>5k races are not scored individually. Instead, your fastest time contributes to the <a href="../races/combined-5k-leaderboard_summary.html">best 5k leaderboard</a>, which is then scored as if it were a single race.</p>
+<table>
+<caption>* denotes race contributes to athlete's total score</caption>
+<tr>
+    <th>Race</th>
+    <th>Date</th>
+    <th>Time</th>
+    <th>Age %</th>
+</tr>
+<tr>
+    <td><a href="../races/sale-sizzler-2_summary.html">Sale sizzler 2</a></td>
+    <td>04/07/2025</td>
+    <td>21:58</td>
+    <td>75.19</td>
+</tr>
+<tr>
+    <td><a href="../races/sale-sizzler-4_summary.html">Sale sizzler 4</a></td>
+    <td>31/07/2025</td>
+    <td>21:39</td>
+    <td>76.29</td>
+</tr>
+<tr>
+    <td><a href="../races/mid-cheshire-summer-5k_summary.html">Mid-Cheshire Summer 5k*</a></td>
+    <td>29/08/2025</td>
+    <td>21:17</td>
+    <td>77.60</td>
 </tr>
 </table>
 <h2>Marathons</h2>

--- a/docs/athletes/hannah-daniel_summary.html
+++ b/docs/athletes/hannah-daniel_summary.html
@@ -27,13 +27,22 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../races/altrincham-10k_summary.html">Altrincham 10k*</a></td>
     <td>07/09/2025</td>
     <td>51:26</td>
     <td>59.14</td>
+    <td>24</td>
+    <td>2</td>
+    <td>26</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td>24</td>
     <td>2</td>
     <td>26</td>

--- a/docs/athletes/ian-blann_summary.html
+++ b/docs/athletes/ian-blann_summary.html
@@ -18,8 +18,6 @@
     <li>Category position: 4 out of 13</li>
 </ul>
 <h2>Club races</h2>
-None
-<h2>5k races</h2>
 <table>
 <caption>* denotes race contributes to athlete's total score</caption>
 <tr>
@@ -29,25 +27,48 @@ None
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
-    <td><a href="../races/sale-sizzler-4_summary.html">Sale sizzler 4</a></td>
-    <td>31/07/2025</td>
-    <td>19:06</td>
-    <td>74.96</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
-</tr>
-<tr>
-    <td><a href="../races/mid-cheshire-summer-5k_summary.html">Mid-Cheshire Summer 5k*</a></td>
+    <td><a href="../races/combined-5k-leaderboard_summary.html">Best 5k*</a></td>
     <td>29/08/2025</td>
     <td>18:12</td>
     <td>79.21</td>
     <td>12</td>
     <td>8</td>
     <td>20</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>12</td>
+    <td>8</td>
+    <td>20</td>
+</tr>
+</table>
+<h2>5k races</h2>
+<p>5k races are not scored individually. Instead, your fastest time contributes to the <a href="../races/combined-5k-leaderboard_summary.html">best 5k leaderboard</a>, which is then scored as if it were a single race.</p>
+<table>
+<caption>* denotes race contributes to athlete's total score</caption>
+<tr>
+    <th>Race</th>
+    <th>Date</th>
+    <th>Time</th>
+    <th>Age %</th>
+</tr>
+<tr>
+    <td><a href="../races/sale-sizzler-4_summary.html">Sale sizzler 4</a></td>
+    <td>31/07/2025</td>
+    <td>19:06</td>
+    <td>74.96</td>
+</tr>
+<tr>
+    <td><a href="../races/mid-cheshire-summer-5k_summary.html">Mid-Cheshire Summer 5k*</a></td>
+    <td>29/08/2025</td>
+    <td>18:12</td>
+    <td>79.21</td>
 </tr>
 </table>
 <h2>Marathons</h2>

--- a/docs/athletes/jack-burbidge_summary.html
+++ b/docs/athletes/jack-burbidge_summary.html
@@ -27,7 +27,7 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../races/wilmslow-summer-10k_summary.html">Wilmslow Summer 10k*</a></td>
@@ -47,8 +47,27 @@
     <td>18</td>
     <td>42</td>
 </tr>
+<tr>
+    <td><a href="../races/combined-5k-leaderboard_summary.html">Best 5k*</a></td>
+    <td>05/09/2025</td>
+    <td>16:33</td>
+    <td>80.16</td>
+    <td>21</td>
+    <td>10</td>
+    <td>31</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>67</td>
+    <td>48</td>
+    <td>115</td>
+</tr>
 </table>
 <h2>5k races</h2>
+<p>5k races are not scored individually. Instead, your fastest time contributes to the <a href="../races/combined-5k-leaderboard_summary.html">best 5k leaderboard</a>, which is then scored as if it were a single race.</p>
 <table>
 <caption>* denotes race contributes to athlete's total score</caption>
 <tr>
@@ -56,45 +75,30 @@
     <th>Date</th>
     <th>Time</th>
     <th>Age %</th>
-    <th>Time score</th>
-    <th>Age % score</th>
-    <th>Total score</th>
 </tr>
 <tr>
     <td><a href="../races/dunham-massey-5k-june_summary.html">Dunham Massey 5k June</a></td>
     <td>05/06/2025</td>
     <td>17:02</td>
     <td>77.89</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
 </tr>
 <tr>
     <td><a href="../races/sale-sizzler-1_summary.html">Sale sizzler 1</a></td>
     <td>19/06/2025</td>
     <td>16:45</td>
     <td>79.20</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
 </tr>
 <tr>
     <td><a href="../races/sale-sizzler-2_summary.html">Sale sizzler 2</a></td>
     <td>04/07/2025</td>
     <td>16:44</td>
     <td>79.28</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
 </tr>
 <tr>
     <td><a href="../races/tameside-september-5k_summary.html">Tameside September 5k*</a></td>
     <td>05/09/2025</td>
     <td>16:33</td>
     <td>80.16</td>
-    <td>21</td>
-    <td>10</td>
-    <td>31</td>
 </tr>
 </table>
 <h2>Marathons</h2>

--- a/docs/athletes/jacob-watson_summary.html
+++ b/docs/athletes/jacob-watson_summary.html
@@ -27,13 +27,22 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../races/altrincham-10k_summary.html">Altrincham 10k*</a></td>
     <td>07/09/2025</td>
     <td>35:05</td>
     <td>80.24</td>
+    <td>22</td>
+    <td>22</td>
+    <td>44</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td>22</td>
     <td>22</td>
     <td>44</td>

--- a/docs/athletes/james-pattison_summary.html
+++ b/docs/athletes/james-pattison_summary.html
@@ -27,7 +27,7 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../races/altrincham-10k_summary.html">Altrincham 10k*</a></td>
@@ -38,21 +38,8 @@
     <td>19</td>
     <td>38</td>
 </tr>
-</table>
-<h2>5k races</h2>
-<table>
-<caption>* denotes race contributes to athlete's total score</caption>
 <tr>
-    <th>Race</th>
-    <th>Date</th>
-    <th>Time</th>
-    <th>Age %</th>
-    <th>Time score</th>
-    <th>Age % score</th>
-    <th>Total score</th>
-</tr>
-<tr>
-    <td><a href="../races/sale-sizzler-3_summary.html">Sale sizzler 3*</a></td>
+    <td><a href="../races/combined-5k-leaderboard_summary.html">Best 5k*</a></td>
     <td>18/07/2025</td>
     <td>17:29</td>
     <td>80.65</td>
@@ -61,13 +48,36 @@
     <td>26</td>
 </tr>
 <tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>33</td>
+    <td>31</td>
+    <td>64</td>
+</tr>
+</table>
+<h2>5k races</h2>
+<p>5k races are not scored individually. Instead, your fastest time contributes to the <a href="../races/combined-5k-leaderboard_summary.html">best 5k leaderboard</a>, which is then scored as if it were a single race.</p>
+<table>
+<caption>* denotes race contributes to athlete's total score</caption>
+<tr>
+    <th>Race</th>
+    <th>Date</th>
+    <th>Time</th>
+    <th>Age %</th>
+</tr>
+<tr>
+    <td><a href="../races/sale-sizzler-3_summary.html">Sale sizzler 3*</a></td>
+    <td>18/07/2025</td>
+    <td>17:29</td>
+    <td>80.65</td>
+</tr>
+<tr>
     <td><a href="../races/sale-sizzler-4_summary.html">Sale sizzler 4</a></td>
     <td>31/07/2025</td>
     <td>17:30</td>
     <td>80.57</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
 </tr>
 </table>
 <h2>Marathons</h2>

--- a/docs/athletes/jo-rosenberg_summary.html
+++ b/docs/athletes/jo-rosenberg_summary.html
@@ -27,13 +27,22 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../races/manchester-half-marathon_summary.html">Manchester Half Marathon*</a></td>
     <td>12/10/2025</td>
     <td>1:22:27</td>
     <td>89.93</td>
+    <td>24</td>
+    <td>25</td>
+    <td>49</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td>24</td>
     <td>25</td>
     <td>49</td>

--- a/docs/athletes/john-noblett_summary.html
+++ b/docs/athletes/john-noblett_summary.html
@@ -27,7 +27,7 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../races/altrincham-10k_summary.html">Altrincham 10k*</a></td>
@@ -38,8 +38,27 @@
     <td>16</td>
     <td>29</td>
 </tr>
+<tr>
+    <td><a href="../races/combined-5k-leaderboard_summary.html">Best 5k*</a></td>
+    <td>18/07/2025</td>
+    <td>22:09</td>
+    <td>71.48</td>
+    <td>0</td>
+    <td>0</td>
+    <td>0</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>13</td>
+    <td>16</td>
+    <td>29</td>
+</tr>
 </table>
 <h2>5k races</h2>
+<p>5k races are not scored individually. Instead, your fastest time contributes to the <a href="../races/combined-5k-leaderboard_summary.html">best 5k leaderboard</a>, which is then scored as if it were a single race.</p>
 <table>
 <caption>* denotes race contributes to athlete's total score</caption>
 <tr>
@@ -47,18 +66,12 @@
     <th>Date</th>
     <th>Time</th>
     <th>Age %</th>
-    <th>Time score</th>
-    <th>Age % score</th>
-    <th>Total score</th>
 </tr>
 <tr>
     <td><a href="../races/sale-sizzler-3_summary.html">Sale sizzler 3*</a></td>
     <td>18/07/2025</td>
     <td>22:09</td>
     <td>71.48</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
 </tr>
 </table>
 <h2>Marathons</h2>

--- a/docs/athletes/john-roche_summary.html
+++ b/docs/athletes/john-roche_summary.html
@@ -27,13 +27,22 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../races/altrincham-10k_summary.html">Altrincham 10k*</a></td>
     <td>07/09/2025</td>
     <td>48:34</td>
     <td>60.84</td>
+    <td>7</td>
+    <td>3</td>
+    <td>10</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td>7</td>
     <td>3</td>
     <td>10</td>

--- a/docs/athletes/jon-preece_summary.html
+++ b/docs/athletes/jon-preece_summary.html
@@ -27,7 +27,7 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../races/wilmslow-summer-10k_summary.html">Wilmslow Summer 10k*</a></td>
@@ -38,21 +38,8 @@
     <td>16</td>
     <td>34</td>
 </tr>
-</table>
-<h2>5k races</h2>
-<table>
-<caption>* denotes race contributes to athlete's total score</caption>
 <tr>
-    <th>Race</th>
-    <th>Date</th>
-    <th>Time</th>
-    <th>Age %</th>
-    <th>Time score</th>
-    <th>Age % score</th>
-    <th>Total score</th>
-</tr>
-<tr>
-    <td><a href="../races/sale-sizzler-3_summary.html">Sale sizzler 3*</a></td>
+    <td><a href="../races/combined-5k-leaderboard_summary.html">Best 5k*</a></td>
     <td>18/07/2025</td>
     <td>20:32</td>
     <td>65.34</td>
@@ -61,13 +48,36 @@
     <td>0</td>
 </tr>
 <tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>18</td>
+    <td>16</td>
+    <td>34</td>
+</tr>
+</table>
+<h2>5k races</h2>
+<p>5k races are not scored individually. Instead, your fastest time contributes to the <a href="../races/combined-5k-leaderboard_summary.html">best 5k leaderboard</a>, which is then scored as if it were a single race.</p>
+<table>
+<caption>* denotes race contributes to athlete's total score</caption>
+<tr>
+    <th>Race</th>
+    <th>Date</th>
+    <th>Time</th>
+    <th>Age %</th>
+</tr>
+<tr>
+    <td><a href="../races/sale-sizzler-3_summary.html">Sale sizzler 3*</a></td>
+    <td>18/07/2025</td>
+    <td>20:32</td>
+    <td>65.34</td>
+</tr>
+<tr>
     <td><a href="../races/sale-sizzler-4_summary.html">Sale sizzler 4</a></td>
     <td>31/07/2025</td>
     <td>20:43</td>
     <td>65.25</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
 </tr>
 </table>
 <h2>Marathons</h2>

--- a/docs/athletes/kate-stuart_summary.html
+++ b/docs/athletes/kate-stuart_summary.html
@@ -27,7 +27,7 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../races/monton-5_summary.html">Monton 5*</a></td>
@@ -38,21 +38,8 @@
     <td>24</td>
     <td>49</td>
 </tr>
-</table>
-<h2>5k races</h2>
-<table>
-<caption>* denotes race contributes to athlete's total score</caption>
 <tr>
-    <th>Race</th>
-    <th>Date</th>
-    <th>Time</th>
-    <th>Age %</th>
-    <th>Time score</th>
-    <th>Age % score</th>
-    <th>Total score</th>
-</tr>
-<tr>
-    <td><a href="../races/dunham-massey-5k-june_summary.html">Dunham Massey 5k June*</a></td>
+    <td><a href="../races/combined-5k-leaderboard_summary.html">Best 5k*</a></td>
     <td>05/06/2025</td>
     <td>21:02</td>
     <td>70.29</td>
@@ -61,13 +48,36 @@
     <td>22</td>
 </tr>
 <tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>47</td>
+    <td>24</td>
+    <td>71</td>
+</tr>
+</table>
+<h2>5k races</h2>
+<p>5k races are not scored individually. Instead, your fastest time contributes to the <a href="../races/combined-5k-leaderboard_summary.html">best 5k leaderboard</a>, which is then scored as if it were a single race.</p>
+<table>
+<caption>* denotes race contributes to athlete's total score</caption>
+<tr>
+    <th>Race</th>
+    <th>Date</th>
+    <th>Time</th>
+    <th>Age %</th>
+</tr>
+<tr>
+    <td><a href="../races/dunham-massey-5k-june_summary.html">Dunham Massey 5k June*</a></td>
+    <td>05/06/2025</td>
+    <td>21:02</td>
+    <td>70.29</td>
+</tr>
+<tr>
     <td><a href="../races/sale-sizzler-4_summary.html">Sale sizzler 4</a></td>
     <td>31/07/2025</td>
     <td>21:41</td>
     <td>68.18</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
 </tr>
 </table>
 <h2>Marathons</h2>

--- a/docs/athletes/katie-livermore_summary.html
+++ b/docs/athletes/katie-livermore_summary.html
@@ -27,7 +27,7 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../races/wilmslow-summer-10k_summary.html">Wilmslow Summer 10k*</a></td>
@@ -46,6 +46,15 @@
     <td>23</td>
     <td>13</td>
     <td>36</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>47</td>
+    <td>27</td>
+    <td>74</td>
 </tr>
 </table>
 <h2>5k races</h2>

--- a/docs/athletes/lora-blann_summary.html
+++ b/docs/athletes/lora-blann_summary.html
@@ -27,7 +27,7 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../races/wilmslow-summer-10k_summary.html">Wilmslow Summer 10k*</a></td>
@@ -46,6 +46,15 @@
     <td>25</td>
     <td>23</td>
     <td>48</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>50</td>
+    <td>44</td>
+    <td>94</td>
 </tr>
 </table>
 <h2>5k races</h2>

--- a/docs/athletes/lorenzo-giove_summary.html
+++ b/docs/athletes/lorenzo-giove_summary.html
@@ -18,8 +18,6 @@
     <li>Category position: 7 out of 13</li>
 </ul>
 <h2>Club races</h2>
-None
-<h2>5k races</h2>
 <table>
 <caption>* denotes race contributes to athlete's total score</caption>
 <tr>
@@ -29,16 +27,42 @@ None
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
-    <td><a href="../races/sale-sizzler-2_summary.html">Sale sizzler 2*</a></td>
+    <td><a href="../races/combined-5k-leaderboard_summary.html">Best 5k*</a></td>
     <td>04/07/2025</td>
     <td>19:56</td>
     <td>71.82</td>
     <td>1</td>
     <td>0</td>
     <td>1</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>1</td>
+    <td>0</td>
+    <td>1</td>
+</tr>
+</table>
+<h2>5k races</h2>
+<p>5k races are not scored individually. Instead, your fastest time contributes to the <a href="../races/combined-5k-leaderboard_summary.html">best 5k leaderboard</a>, which is then scored as if it were a single race.</p>
+<table>
+<caption>* denotes race contributes to athlete's total score</caption>
+<tr>
+    <th>Race</th>
+    <th>Date</th>
+    <th>Time</th>
+    <th>Age %</th>
+</tr>
+<tr>
+    <td><a href="../races/sale-sizzler-2_summary.html">Sale sizzler 2*</a></td>
+    <td>04/07/2025</td>
+    <td>19:56</td>
+    <td>71.82</td>
 </tr>
 </table>
 <h2>Marathons</h2>

--- a/docs/athletes/luke-baumber_summary.html
+++ b/docs/athletes/luke-baumber_summary.html
@@ -18,8 +18,6 @@
     <li>Category position: 10 out of 21</li>
 </ul>
 <h2>Club races</h2>
-None
-<h2>5k races</h2>
 <table>
 <caption>* denotes race contributes to athlete's total score</caption>
 <tr>
@@ -29,34 +27,54 @@ None
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
-    <td><a href="../races/sale-sizzler-2_summary.html">Sale sizzler 2</a></td>
-    <td>04/07/2025</td>
-    <td>20:09</td>
-    <td>64.43</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
-</tr>
-<tr>
-    <td><a href="../races/sale-sizzler-4_summary.html">Sale sizzler 4</a></td>
-    <td>31/07/2025</td>
-    <td>20:03</td>
-    <td>64.75</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
-</tr>
-<tr>
-    <td><a href="../races/mid-cheshire-summer-5k_summary.html">Mid-Cheshire Summer 5k*</a></td>
+    <td><a href="../races/combined-5k-leaderboard_summary.html">Best 5k*</a></td>
     <td>29/08/2025</td>
     <td>19:52</td>
     <td>65.35</td>
     <td>2</td>
     <td>0</td>
     <td>2</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>2</td>
+    <td>0</td>
+    <td>2</td>
+</tr>
+</table>
+<h2>5k races</h2>
+<p>5k races are not scored individually. Instead, your fastest time contributes to the <a href="../races/combined-5k-leaderboard_summary.html">best 5k leaderboard</a>, which is then scored as if it were a single race.</p>
+<table>
+<caption>* denotes race contributes to athlete's total score</caption>
+<tr>
+    <th>Race</th>
+    <th>Date</th>
+    <th>Time</th>
+    <th>Age %</th>
+</tr>
+<tr>
+    <td><a href="../races/sale-sizzler-2_summary.html">Sale sizzler 2</a></td>
+    <td>04/07/2025</td>
+    <td>20:09</td>
+    <td>64.43</td>
+</tr>
+<tr>
+    <td><a href="../races/sale-sizzler-4_summary.html">Sale sizzler 4</a></td>
+    <td>31/07/2025</td>
+    <td>20:03</td>
+    <td>64.75</td>
+</tr>
+<tr>
+    <td><a href="../races/mid-cheshire-summer-5k_summary.html">Mid-Cheshire Summer 5k*</a></td>
+    <td>29/08/2025</td>
+    <td>19:52</td>
+    <td>65.35</td>
 </tr>
 </table>
 <h2>Marathons</h2>

--- a/docs/athletes/luke-hornby_summary.html
+++ b/docs/athletes/luke-hornby_summary.html
@@ -18,8 +18,6 @@
     <li>Category position: 5 out of 21</li>
 </ul>
 <h2>Club races</h2>
-None
-<h2>5k races</h2>
 <table>
 <caption>* denotes race contributes to athlete's total score</caption>
 <tr>
@@ -29,34 +27,54 @@ None
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
-    <td><a href="../races/sale-sizzler-4_summary.html">Sale sizzler 4</a></td>
-    <td>31/07/2025</td>
-    <td>16:07</td>
-    <td>80.56</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
-</tr>
-<tr>
-    <td><a href="../races/ellesmere-port-5k_summary.html">Ellesmere port 5k</a></td>
-    <td>13/08/2025</td>
-    <td>15:53</td>
-    <td>81.74</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
-</tr>
-<tr>
-    <td><a href="../races/mid-cheshire-summer-5k_summary.html">Mid-Cheshire Summer 5k*</a></td>
+    <td><a href="../races/combined-5k-leaderboard_summary.html">Best 5k*</a></td>
     <td>29/08/2025</td>
     <td>15:39</td>
     <td>82.96</td>
     <td>25</td>
     <td>19</td>
     <td>44</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>25</td>
+    <td>19</td>
+    <td>44</td>
+</tr>
+</table>
+<h2>5k races</h2>
+<p>5k races are not scored individually. Instead, your fastest time contributes to the <a href="../races/combined-5k-leaderboard_summary.html">best 5k leaderboard</a>, which is then scored as if it were a single race.</p>
+<table>
+<caption>* denotes race contributes to athlete's total score</caption>
+<tr>
+    <th>Race</th>
+    <th>Date</th>
+    <th>Time</th>
+    <th>Age %</th>
+</tr>
+<tr>
+    <td><a href="../races/sale-sizzler-4_summary.html">Sale sizzler 4</a></td>
+    <td>31/07/2025</td>
+    <td>16:07</td>
+    <td>80.56</td>
+</tr>
+<tr>
+    <td><a href="../races/ellesmere-port-5k_summary.html">Ellesmere port 5k</a></td>
+    <td>13/08/2025</td>
+    <td>15:53</td>
+    <td>81.74</td>
+</tr>
+<tr>
+    <td><a href="../races/mid-cheshire-summer-5k_summary.html">Mid-Cheshire Summer 5k*</a></td>
+    <td>29/08/2025</td>
+    <td>15:39</td>
+    <td>82.96</td>
 </tr>
 </table>
 <h2>Marathons</h2>

--- a/docs/athletes/luke-moulton_summary.html
+++ b/docs/athletes/luke-moulton_summary.html
@@ -27,7 +27,7 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../races/wilmslow-summer-10k_summary.html">Wilmslow Summer 10k*</a></td>
@@ -38,8 +38,27 @@
     <td>22</td>
     <td>45</td>
 </tr>
+<tr>
+    <td><a href="../races/combined-5k-leaderboard_summary.html">Best 5k*</a></td>
+    <td>29/08/2025</td>
+    <td>16:35</td>
+    <td>80.90</td>
+    <td>20</td>
+    <td>13</td>
+    <td>33</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>43</td>
+    <td>35</td>
+    <td>78</td>
+</tr>
 </table>
 <h2>5k races</h2>
+<p>5k races are not scored individually. Instead, your fastest time contributes to the <a href="../races/combined-5k-leaderboard_summary.html">best 5k leaderboard</a>, which is then scored as if it were a single race.</p>
 <table>
 <caption>* denotes race contributes to athlete's total score</caption>
 <tr>
@@ -47,45 +66,30 @@
     <th>Date</th>
     <th>Time</th>
     <th>Age %</th>
-    <th>Time score</th>
-    <th>Age % score</th>
-    <th>Total score</th>
 </tr>
 <tr>
     <td><a href="../races/sale-sizzler-2_summary.html">Sale sizzler 2</a></td>
     <td>04/07/2025</td>
     <td>16:45</td>
     <td>79.60</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
 </tr>
 <tr>
     <td><a href="../races/sale-sizzler-3_summary.html">Sale sizzler 3</a></td>
     <td>18/07/2025</td>
     <td>16:57</td>
     <td>78.66</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
 </tr>
 <tr>
     <td><a href="../races/ellesmere-port-5k_summary.html">Ellesmere port 5k</a></td>
     <td>13/08/2025</td>
     <td>16:48</td>
     <td>79.86</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
 </tr>
 <tr>
     <td><a href="../races/mid-cheshire-summer-5k_summary.html">Mid-Cheshire Summer 5k*</a></td>
     <td>29/08/2025</td>
     <td>16:35</td>
     <td>80.90</td>
-    <td>20</td>
-    <td>13</td>
-    <td>33</td>
 </tr>
 </table>
 <h2>Marathons</h2>

--- a/docs/athletes/mark-newton_summary.html
+++ b/docs/athletes/mark-newton_summary.html
@@ -27,7 +27,7 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../races/altrincham-10k_summary.html">Altrincham 10k*</a></td>
@@ -38,21 +38,8 @@
     <td>15</td>
     <td>29</td>
 </tr>
-</table>
-<h2>5k races</h2>
-<table>
-<caption>* denotes race contributes to athlete's total score</caption>
 <tr>
-    <th>Race</th>
-    <th>Date</th>
-    <th>Time</th>
-    <th>Age %</th>
-    <th>Time score</th>
-    <th>Age % score</th>
-    <th>Total score</th>
-</tr>
-<tr>
-    <td><a href="../races/dunham-massey-5k-june_summary.html">Dunham Massey 5k June*</a></td>
+    <td><a href="../races/combined-5k-leaderboard_summary.html">Best 5k*</a></td>
     <td>05/06/2025</td>
     <td>19:57</td>
     <td>76.86</td>
@@ -61,13 +48,36 @@
     <td>5</td>
 </tr>
 <tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>14</td>
+    <td>20</td>
+    <td>34</td>
+</tr>
+</table>
+<h2>5k races</h2>
+<p>5k races are not scored individually. Instead, your fastest time contributes to the <a href="../races/combined-5k-leaderboard_summary.html">best 5k leaderboard</a>, which is then scored as if it were a single race.</p>
+<table>
+<caption>* denotes race contributes to athlete's total score</caption>
+<tr>
+    <th>Race</th>
+    <th>Date</th>
+    <th>Time</th>
+    <th>Age %</th>
+</tr>
+<tr>
+    <td><a href="../races/dunham-massey-5k-june_summary.html">Dunham Massey 5k June*</a></td>
+    <td>05/06/2025</td>
+    <td>19:57</td>
+    <td>76.86</td>
+</tr>
+<tr>
     <td><a href="../races/sale-sizzler-1_summary.html">Sale sizzler 1</a></td>
     <td>19/06/2025</td>
     <td>20:16</td>
     <td>75.66</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
 </tr>
 </table>
 <h2>Marathons</h2>

--- a/docs/athletes/matthew-allen_summary.html
+++ b/docs/athletes/matthew-allen_summary.html
@@ -27,7 +27,7 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../races/manchester-half-marathon_summary.html">Manchester Half Marathon*</a></td>
@@ -38,8 +38,27 @@
     <td>17</td>
     <td>38</td>
 </tr>
+<tr>
+    <td><a href="../races/combined-5k-leaderboard_summary.html">Best 5k*</a></td>
+    <td>31/07/2025</td>
+    <td>19:15</td>
+    <td>71.69</td>
+    <td>8</td>
+    <td>0</td>
+    <td>8</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>29</td>
+    <td>17</td>
+    <td>46</td>
+</tr>
 </table>
 <h2>5k races</h2>
+<p>5k races are not scored individually. Instead, your fastest time contributes to the <a href="../races/combined-5k-leaderboard_summary.html">best 5k leaderboard</a>, which is then scored as if it were a single race.</p>
 <table>
 <caption>* denotes race contributes to athlete's total score</caption>
 <tr>
@@ -47,27 +66,18 @@
     <th>Date</th>
     <th>Time</th>
     <th>Age %</th>
-    <th>Time score</th>
-    <th>Age % score</th>
-    <th>Total score</th>
 </tr>
 <tr>
     <td><a href="../races/sale-sizzler-1_summary.html">Sale sizzler 1</a></td>
     <td>19/06/2025</td>
     <td>20:32</td>
     <td>67.21</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
 </tr>
 <tr>
     <td><a href="../races/sale-sizzler-4_summary.html">Sale sizzler 4*</a></td>
     <td>31/07/2025</td>
     <td>19:15</td>
     <td>71.69</td>
-    <td>8</td>
-    <td>0</td>
-    <td>8</td>
 </tr>
 </table>
 <h2>Marathons</h2>

--- a/docs/athletes/matthew-beacock_summary.html
+++ b/docs/athletes/matthew-beacock_summary.html
@@ -27,7 +27,7 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../races/altrincham-10k_summary.html">Altrincham 10k*</a></td>
@@ -46,6 +46,15 @@
     <td>23</td>
     <td>18</td>
     <td>41</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>41</td>
+    <td>28</td>
+    <td>69</td>
 </tr>
 </table>
 <h2>5k races</h2>

--- a/docs/athletes/michael-berks_summary.html
+++ b/docs/athletes/michael-berks_summary.html
@@ -27,7 +27,7 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../races/wizard-5_summary.html">Wizard 5*</a></td>
@@ -38,8 +38,27 @@
     <td>24</td>
     <td>49</td>
 </tr>
+<tr>
+    <td><a href="../races/combined-5k-leaderboard_summary.html">Best 5k*</a></td>
+    <td>29/08/2025</td>
+    <td>15:54</td>
+    <td>87.42</td>
+    <td>24</td>
+    <td>24</td>
+    <td>48</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>49</td>
+    <td>48</td>
+    <td>97</td>
+</tr>
 </table>
 <h2>5k races</h2>
+<p>5k races are not scored individually. Instead, your fastest time contributes to the <a href="../races/combined-5k-leaderboard_summary.html">best 5k leaderboard</a>, which is then scored as if it were a single race.</p>
 <table>
 <caption>* denotes race contributes to athlete's total score</caption>
 <tr>
@@ -47,36 +66,24 @@
     <th>Date</th>
     <th>Time</th>
     <th>Age %</th>
-    <th>Time score</th>
-    <th>Age % score</th>
-    <th>Total score</th>
 </tr>
 <tr>
     <td><a href="../races/sale-sizzler-1_summary.html">Sale sizzler 1</a></td>
     <td>19/06/2025</td>
     <td>16:06</td>
     <td>86.34</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
 </tr>
 <tr>
     <td><a href="../races/sale-sizzler-2_summary.html">Sale sizzler 2</a></td>
     <td>04/07/2025</td>
     <td>16:00</td>
     <td>86.88</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
 </tr>
 <tr>
     <td><a href="../races/mid-cheshire-summer-5k_summary.html">Mid-Cheshire Summer 5k*</a></td>
     <td>29/08/2025</td>
     <td>15:54</td>
     <td>87.42</td>
-    <td>24</td>
-    <td>24</td>
-    <td>48</td>
 </tr>
 </table>
 <h2>Marathons</h2>

--- a/docs/athletes/michael-whitham_summary.html
+++ b/docs/athletes/michael-whitham_summary.html
@@ -27,7 +27,7 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../races/wilmslow-summer-10k_summary.html">Wilmslow Summer 10k*</a></td>
@@ -46,6 +46,15 @@
     <td>25</td>
     <td>21</td>
     <td>46</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>49</td>
+    <td>44</td>
+    <td>93</td>
 </tr>
 </table>
 <h2>5k races</h2>

--- a/docs/athletes/nadia-erdenesuren_summary.html
+++ b/docs/athletes/nadia-erdenesuren_summary.html
@@ -27,7 +27,7 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../races/altrincham-10k_summary.html">Altrincham 10k*</a></td>
@@ -47,8 +47,27 @@
     <td>16</td>
     <td>38</td>
 </tr>
+<tr>
+    <td><a href="../races/combined-5k-leaderboard_summary.html">Best 5k*</a></td>
+    <td>05/06/2025</td>
+    <td>24:30</td>
+    <td>67.41</td>
+    <td>18</td>
+    <td>0</td>
+    <td>18</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>63</td>
+    <td>22</td>
+    <td>85</td>
+</tr>
 </table>
 <h2>5k races</h2>
+<p>5k races are not scored individually. Instead, your fastest time contributes to the <a href="../races/combined-5k-leaderboard_summary.html">best 5k leaderboard</a>, which is then scored as if it were a single race.</p>
 <table>
 <caption>* denotes race contributes to athlete's total score</caption>
 <tr>
@@ -56,18 +75,12 @@
     <th>Date</th>
     <th>Time</th>
     <th>Age %</th>
-    <th>Time score</th>
-    <th>Age % score</th>
-    <th>Total score</th>
 </tr>
 <tr>
     <td><a href="../races/dunham-massey-5k-june_summary.html">Dunham Massey 5k June*</a></td>
     <td>05/06/2025</td>
     <td>24:30</td>
     <td>67.41</td>
-    <td>18</td>
-    <td>0</td>
-    <td>18</td>
 </tr>
 </table>
 <h2>Marathons</h2>

--- a/docs/athletes/nick-bugler_summary.html
+++ b/docs/athletes/nick-bugler_summary.html
@@ -18,8 +18,6 @@
     <li>Category position: 6 out of 10</li>
 </ul>
 <h2>Club races</h2>
-None
-<h2>5k races</h2>
 <table>
 <caption>* denotes race contributes to athlete's total score</caption>
 <tr>
@@ -29,10 +27,10 @@ None
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
-    <td><a href="../races/sale-sizzler-1_summary.html">Sale sizzler 1*</a></td>
+    <td><a href="../races/combined-5k-leaderboard_summary.html">Best 5k*</a></td>
     <td>19/06/2025</td>
     <td>17:58</td>
     <td>74.21</td>
@@ -41,13 +39,36 @@ None
     <td>13</td>
 </tr>
 <tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>13</td>
+    <td>0</td>
+    <td>13</td>
+</tr>
+</table>
+<h2>5k races</h2>
+<p>5k races are not scored individually. Instead, your fastest time contributes to the <a href="../races/combined-5k-leaderboard_summary.html">best 5k leaderboard</a>, which is then scored as if it were a single race.</p>
+<table>
+<caption>* denotes race contributes to athlete's total score</caption>
+<tr>
+    <th>Race</th>
+    <th>Date</th>
+    <th>Time</th>
+    <th>Age %</th>
+</tr>
+<tr>
+    <td><a href="../races/sale-sizzler-1_summary.html">Sale sizzler 1*</a></td>
+    <td>19/06/2025</td>
+    <td>17:58</td>
+    <td>74.21</td>
+</tr>
+<tr>
     <td><a href="../races/mid-cheshire-summer-5k_summary.html">Mid-Cheshire Summer 5k</a></td>
     <td>29/08/2025</td>
     <td>22:07</td>
     <td>60.29</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
 </tr>
 </table>
 <h2>Marathons</h2>

--- a/docs/athletes/nick-cuff_summary.html
+++ b/docs/athletes/nick-cuff_summary.html
@@ -27,13 +27,22 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../races/wilmslow-summer-10k_summary.html">Wilmslow Summer 10k*</a></td>
     <td>13/07/2025</td>
     <td>39:35</td>
     <td>68.38</td>
+    <td>21</td>
+    <td>18</td>
+    <td>39</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td>21</td>
     <td>18</td>
     <td>39</td>

--- a/docs/athletes/paul-abraham_summary.html
+++ b/docs/athletes/paul-abraham_summary.html
@@ -27,7 +27,7 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../races/manchester-half-marathon_summary.html">Manchester Half Marathon*</a></td>
@@ -38,8 +38,27 @@
     <td>21</td>
     <td>41</td>
 </tr>
+<tr>
+    <td><a href="../races/combined-5k-leaderboard_summary.html">Best 5k*</a></td>
+    <td>04/07/2025</td>
+    <td>19:45</td>
+    <td>76.46</td>
+    <td>5</td>
+    <td>4</td>
+    <td>9</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>25</td>
+    <td>25</td>
+    <td>50</td>
+</tr>
 </table>
 <h2>5k races</h2>
+<p>5k races are not scored individually. Instead, your fastest time contributes to the <a href="../races/combined-5k-leaderboard_summary.html">best 5k leaderboard</a>, which is then scored as if it were a single race.</p>
 <table>
 <caption>* denotes race contributes to athlete's total score</caption>
 <tr>
@@ -47,18 +66,12 @@
     <th>Date</th>
     <th>Time</th>
     <th>Age %</th>
-    <th>Time score</th>
-    <th>Age % score</th>
-    <th>Total score</th>
 </tr>
 <tr>
     <td><a href="../races/sale-sizzler-2_summary.html">Sale sizzler 2*</a></td>
     <td>04/07/2025</td>
     <td>19:45</td>
     <td>76.46</td>
-    <td>5</td>
-    <td>4</td>
-    <td>9</td>
 </tr>
 </table>
 <h2>Marathons</h2>

--- a/docs/athletes/peter-waterson_summary.html
+++ b/docs/athletes/peter-waterson_summary.html
@@ -27,13 +27,22 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../races/altrincham-10k_summary.html">Altrincham 10k*</a></td>
     <td>07/09/2025</td>
     <td>44:55</td>
     <td>70.43</td>
+    <td>12</td>
+    <td>13</td>
+    <td>25</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td>12</td>
     <td>13</td>
     <td>25</td>

--- a/docs/athletes/phil-raffo_summary.html
+++ b/docs/athletes/phil-raffo_summary.html
@@ -27,13 +27,22 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../races/altrincham-10k_summary.html">Altrincham 10k*</a></td>
     <td>07/09/2025</td>
     <td>34:59</td>
     <td>79.23</td>
+    <td>23</td>
+    <td>20</td>
+    <td>43</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td>23</td>
     <td>20</td>
     <td>43</td>

--- a/docs/athletes/richard-evans_summary.html
+++ b/docs/athletes/richard-evans_summary.html
@@ -18,8 +18,6 @@
     <li>Category position: 6 out of 19</li>
 </ul>
 <h2>Club races</h2>
-None
-<h2>5k races</h2>
 <table>
 <caption>* denotes race contributes to athlete's total score</caption>
 <tr>
@@ -29,25 +27,48 @@ None
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
-    <td><a href="../races/dunham-massey-5k-june_summary.html">Dunham Massey 5k June</a></td>
-    <td>05/06/2025</td>
-    <td>19:43</td>
-    <td>80.30</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
-</tr>
-<tr>
-    <td><a href="../races/sale-sizzler-1_summary.html">Sale sizzler 1*</a></td>
+    <td><a href="../races/combined-5k-leaderboard_summary.html">Best 5k*</a></td>
     <td>19/06/2025</td>
     <td>19:23</td>
     <td>81.69</td>
     <td>7</td>
     <td>15</td>
     <td>22</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>7</td>
+    <td>15</td>
+    <td>22</td>
+</tr>
+</table>
+<h2>5k races</h2>
+<p>5k races are not scored individually. Instead, your fastest time contributes to the <a href="../races/combined-5k-leaderboard_summary.html">best 5k leaderboard</a>, which is then scored as if it were a single race.</p>
+<table>
+<caption>* denotes race contributes to athlete's total score</caption>
+<tr>
+    <th>Race</th>
+    <th>Date</th>
+    <th>Time</th>
+    <th>Age %</th>
+</tr>
+<tr>
+    <td><a href="../races/dunham-massey-5k-june_summary.html">Dunham Massey 5k June</a></td>
+    <td>05/06/2025</td>
+    <td>19:43</td>
+    <td>80.30</td>
+</tr>
+<tr>
+    <td><a href="../races/sale-sizzler-1_summary.html">Sale sizzler 1*</a></td>
+    <td>19/06/2025</td>
+    <td>19:23</td>
+    <td>81.69</td>
 </tr>
 </table>
 <h2>Marathons</h2>

--- a/docs/athletes/richard-hill_summary.html
+++ b/docs/athletes/richard-hill_summary.html
@@ -27,7 +27,7 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../races/altrincham-10k_summary.html">Altrincham 10k*</a></td>
@@ -38,30 +38,8 @@
     <td>5</td>
     <td>14</td>
 </tr>
-</table>
-<h2>5k races</h2>
-<table>
-<caption>* denotes race contributes to athlete's total score</caption>
 <tr>
-    <th>Race</th>
-    <th>Date</th>
-    <th>Time</th>
-    <th>Age %</th>
-    <th>Time score</th>
-    <th>Age % score</th>
-    <th>Total score</th>
-</tr>
-<tr>
-    <td><a href="../races/sale-sizzler-2_summary.html">Sale sizzler 2</a></td>
-    <td>04/07/2025</td>
-    <td>20:46</td>
-    <td>68.46</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
-</tr>
-<tr>
-    <td><a href="../races/sale-sizzler-3_summary.html">Sale sizzler 3*</a></td>
+    <td><a href="../races/combined-5k-leaderboard_summary.html">Best 5k*</a></td>
     <td>18/07/2025</td>
     <td>20:42</td>
     <td>68.68</td>
@@ -70,13 +48,42 @@
     <td>0</td>
 </tr>
 <tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>9</td>
+    <td>5</td>
+    <td>14</td>
+</tr>
+</table>
+<h2>5k races</h2>
+<p>5k races are not scored individually. Instead, your fastest time contributes to the <a href="../races/combined-5k-leaderboard_summary.html">best 5k leaderboard</a>, which is then scored as if it were a single race.</p>
+<table>
+<caption>* denotes race contributes to athlete's total score</caption>
+<tr>
+    <th>Race</th>
+    <th>Date</th>
+    <th>Time</th>
+    <th>Age %</th>
+</tr>
+<tr>
+    <td><a href="../races/sale-sizzler-2_summary.html">Sale sizzler 2</a></td>
+    <td>04/07/2025</td>
+    <td>20:46</td>
+    <td>68.46</td>
+</tr>
+<tr>
+    <td><a href="../races/sale-sizzler-3_summary.html">Sale sizzler 3*</a></td>
+    <td>18/07/2025</td>
+    <td>20:42</td>
+    <td>68.68</td>
+</tr>
+<tr>
     <td><a href="../races/sale-sizzler-4_summary.html">Sale sizzler 4</a></td>
     <td>31/07/2025</td>
     <td>20:52</td>
     <td>68.13</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
 </tr>
 </table>
 <h2>Marathons</h2>

--- a/docs/athletes/richard-jellyman_summary.html
+++ b/docs/athletes/richard-jellyman_summary.html
@@ -27,13 +27,22 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../races/manchester-half-marathon_summary.html">Manchester Half Marathon*</a></td>
     <td>12/10/2025</td>
     <td>1:23:06</td>
     <td>72.74</td>
+    <td>22</td>
+    <td>20</td>
+    <td>42</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td>22</td>
     <td>20</td>
     <td>42</td>

--- a/docs/athletes/richard-johnson_summary.html
+++ b/docs/athletes/richard-johnson_summary.html
@@ -27,13 +27,22 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../races/altrincham-10k_summary.html">Altrincham 10k*</a></td>
     <td>07/09/2025</td>
     <td>36:30</td>
     <td>89.04</td>
+    <td>20</td>
+    <td>25</td>
+    <td>45</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td>20</td>
     <td>25</td>
     <td>45</td>

--- a/docs/athletes/ruth-tidd_summary.html
+++ b/docs/athletes/ruth-tidd_summary.html
@@ -18,8 +18,6 @@
     <li>Category position: 2 out of 3</li>
 </ul>
 <h2>Club races</h2>
-None
-<h2>5k races</h2>
 <table>
 <caption>* denotes race contributes to athlete's total score</caption>
 <tr>
@@ -29,25 +27,48 @@ None
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
-    <td><a href="../races/sale-sizzler-1_summary.html">Sale sizzler 1</a></td>
-    <td>19/06/2025</td>
-    <td>21:47</td>
-    <td>69.63</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
-</tr>
-<tr>
-    <td><a href="../races/sale-sizzler-3_summary.html">Sale sizzler 3*</a></td>
+    <td><a href="../races/combined-5k-leaderboard_summary.html">Best 5k*</a></td>
     <td>18/07/2025</td>
     <td>21:19</td>
     <td>71.54</td>
     <td>21</td>
     <td>0</td>
     <td>21</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>21</td>
+    <td>0</td>
+    <td>21</td>
+</tr>
+</table>
+<h2>5k races</h2>
+<p>5k races are not scored individually. Instead, your fastest time contributes to the <a href="../races/combined-5k-leaderboard_summary.html">best 5k leaderboard</a>, which is then scored as if it were a single race.</p>
+<table>
+<caption>* denotes race contributes to athlete's total score</caption>
+<tr>
+    <th>Race</th>
+    <th>Date</th>
+    <th>Time</th>
+    <th>Age %</th>
+</tr>
+<tr>
+    <td><a href="../races/sale-sizzler-1_summary.html">Sale sizzler 1</a></td>
+    <td>19/06/2025</td>
+    <td>21:47</td>
+    <td>69.63</td>
+</tr>
+<tr>
+    <td><a href="../races/sale-sizzler-3_summary.html">Sale sizzler 3*</a></td>
+    <td>18/07/2025</td>
+    <td>21:19</td>
+    <td>71.54</td>
 </tr>
 </table>
 <h2>Marathons</h2>

--- a/docs/athletes/ryan-teare_summary.html
+++ b/docs/athletes/ryan-teare_summary.html
@@ -27,7 +27,7 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../races/altrincham-10k_summary.html">Altrincham 10k*</a></td>
@@ -38,39 +38,8 @@
     <td>17</td>
     <td>38</td>
 </tr>
-</table>
-<h2>5k races</h2>
-<table>
-<caption>* denotes race contributes to athlete's total score</caption>
 <tr>
-    <th>Race</th>
-    <th>Date</th>
-    <th>Time</th>
-    <th>Age %</th>
-    <th>Time score</th>
-    <th>Age % score</th>
-    <th>Total score</th>
-</tr>
-<tr>
-    <td><a href="../races/dunham-massey-5k-june_summary.html">Dunham Massey 5k June</a></td>
-    <td>05/06/2025</td>
-    <td>17:07</td>
-    <td>75.85</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
-</tr>
-<tr>
-    <td><a href="../races/sale-sizzler-1_summary.html">Sale sizzler 1</a></td>
-    <td>19/06/2025</td>
-    <td>17:19</td>
-    <td>74.98</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
-</tr>
-<tr>
-    <td><a href="../races/sale-sizzler-3_summary.html">Sale sizzler 3*</a></td>
+    <td><a href="../races/combined-5k-leaderboard_summary.html">Best 5k*</a></td>
     <td>18/07/2025</td>
     <td>16:46</td>
     <td>77.44</td>
@@ -79,13 +48,48 @@
     <td>25</td>
 </tr>
 <tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>40</td>
+    <td>23</td>
+    <td>63</td>
+</tr>
+</table>
+<h2>5k races</h2>
+<p>5k races are not scored individually. Instead, your fastest time contributes to the <a href="../races/combined-5k-leaderboard_summary.html">best 5k leaderboard</a>, which is then scored as if it were a single race.</p>
+<table>
+<caption>* denotes race contributes to athlete's total score</caption>
+<tr>
+    <th>Race</th>
+    <th>Date</th>
+    <th>Time</th>
+    <th>Age %</th>
+</tr>
+<tr>
+    <td><a href="../races/dunham-massey-5k-june_summary.html">Dunham Massey 5k June</a></td>
+    <td>05/06/2025</td>
+    <td>17:07</td>
+    <td>75.85</td>
+</tr>
+<tr>
+    <td><a href="../races/sale-sizzler-1_summary.html">Sale sizzler 1</a></td>
+    <td>19/06/2025</td>
+    <td>17:19</td>
+    <td>74.98</td>
+</tr>
+<tr>
+    <td><a href="../races/sale-sizzler-3_summary.html">Sale sizzler 3*</a></td>
+    <td>18/07/2025</td>
+    <td>16:46</td>
+    <td>77.44</td>
+</tr>
+<tr>
     <td><a href="../races/sale-sizzler-4_summary.html">Sale sizzler 4</a></td>
     <td>31/07/2025</td>
     <td>16:50</td>
     <td>77.13</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
 </tr>
 </table>
 <h2>Marathons</h2>

--- a/docs/athletes/sam-higgs_summary.html
+++ b/docs/athletes/sam-higgs_summary.html
@@ -27,7 +27,7 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../races/wilmslow-summer-10k_summary.html">Wilmslow Summer 10k*</a></td>
@@ -47,8 +47,27 @@
     <td>0</td>
     <td>4</td>
 </tr>
+<tr>
+    <td><a href="../races/combined-5k-leaderboard_summary.html">Best 5k*</a></td>
+    <td>05/06/2025</td>
+    <td>21:37</td>
+    <td>60.06</td>
+    <td>0</td>
+    <td>0</td>
+    <td>0</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>21</td>
+    <td>15</td>
+    <td>36</td>
+</tr>
 </table>
 <h2>5k races</h2>
+<p>5k races are not scored individually. Instead, your fastest time contributes to the <a href="../races/combined-5k-leaderboard_summary.html">best 5k leaderboard</a>, which is then scored as if it were a single race.</p>
 <table>
 <caption>* denotes race contributes to athlete's total score</caption>
 <tr>
@@ -56,18 +75,12 @@
     <th>Date</th>
     <th>Time</th>
     <th>Age %</th>
-    <th>Time score</th>
-    <th>Age % score</th>
-    <th>Total score</th>
 </tr>
 <tr>
     <td><a href="../races/dunham-massey-5k-june_summary.html">Dunham Massey 5k June*</a></td>
     <td>05/06/2025</td>
     <td>21:37</td>
     <td>60.06</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
 </tr>
 </table>
 <h2>Marathons</h2>

--- a/docs/athletes/sarah-king_summary.html
+++ b/docs/athletes/sarah-king_summary.html
@@ -18,8 +18,6 @@
     <li>Category position: 1 out of 3</li>
 </ul>
 <h2>Club races</h2>
-None
-<h2>5k races</h2>
 <table>
 <caption>* denotes race contributes to athlete's total score</caption>
 <tr>
@@ -29,34 +27,54 @@ None
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
-    <td><a href="../races/sale-sizzler-1_summary.html">Sale sizzler 1</a></td>
-    <td>19/06/2025</td>
-    <td>19:58</td>
-    <td>75.54</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
-</tr>
-<tr>
-    <td><a href="../races/sale-sizzler-4_summary.html">Sale sizzler 4</a></td>
-    <td>31/07/2025</td>
-    <td>19:24</td>
-    <td>77.75</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
-</tr>
-<tr>
-    <td><a href="../races/mid-cheshire-summer-5k_summary.html">Mid-Cheshire Summer 5k*</a></td>
+    <td><a href="../races/combined-5k-leaderboard_summary.html">Best 5k*</a></td>
     <td>29/08/2025</td>
     <td>18:56</td>
     <td>79.67</td>
     <td>24</td>
     <td>9</td>
     <td>33</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>24</td>
+    <td>9</td>
+    <td>33</td>
+</tr>
+</table>
+<h2>5k races</h2>
+<p>5k races are not scored individually. Instead, your fastest time contributes to the <a href="../races/combined-5k-leaderboard_summary.html">best 5k leaderboard</a>, which is then scored as if it were a single race.</p>
+<table>
+<caption>* denotes race contributes to athlete's total score</caption>
+<tr>
+    <th>Race</th>
+    <th>Date</th>
+    <th>Time</th>
+    <th>Age %</th>
+</tr>
+<tr>
+    <td><a href="../races/sale-sizzler-1_summary.html">Sale sizzler 1</a></td>
+    <td>19/06/2025</td>
+    <td>19:58</td>
+    <td>75.54</td>
+</tr>
+<tr>
+    <td><a href="../races/sale-sizzler-4_summary.html">Sale sizzler 4</a></td>
+    <td>31/07/2025</td>
+    <td>19:24</td>
+    <td>77.75</td>
+</tr>
+<tr>
+    <td><a href="../races/mid-cheshire-summer-5k_summary.html">Mid-Cheshire Summer 5k*</a></td>
+    <td>29/08/2025</td>
+    <td>18:56</td>
+    <td>79.67</td>
 </tr>
 </table>
 <h2>Marathons</h2>

--- a/docs/athletes/simon-bareford_summary.html
+++ b/docs/athletes/simon-bareford_summary.html
@@ -18,8 +18,6 @@
     <li>Category position: 2 out of 13</li>
 </ul>
 <h2>Club races</h2>
-None
-<h2>5k races</h2>
 <table>
 <caption>* denotes race contributes to athlete's total score</caption>
 <tr>
@@ -29,25 +27,48 @@ None
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
-    <td><a href="../races/dunham-massey-5k-june_summary.html">Dunham Massey 5k June</a></td>
-    <td>05/06/2025</td>
-    <td>20:12</td>
-    <td>70.87</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
-</tr>
-<tr>
-    <td><a href="../races/sale-sizzler-1_summary.html">Sale sizzler 1*</a></td>
+    <td><a href="../races/combined-5k-leaderboard_summary.html">Best 5k*</a></td>
     <td>19/06/2025</td>
     <td>17:25</td>
     <td>82.20</td>
     <td>15</td>
     <td>16</td>
     <td>31</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>15</td>
+    <td>16</td>
+    <td>31</td>
+</tr>
+</table>
+<h2>5k races</h2>
+<p>5k races are not scored individually. Instead, your fastest time contributes to the <a href="../races/combined-5k-leaderboard_summary.html">best 5k leaderboard</a>, which is then scored as if it were a single race.</p>
+<table>
+<caption>* denotes race contributes to athlete's total score</caption>
+<tr>
+    <th>Race</th>
+    <th>Date</th>
+    <th>Time</th>
+    <th>Age %</th>
+</tr>
+<tr>
+    <td><a href="../races/dunham-massey-5k-june_summary.html">Dunham Massey 5k June</a></td>
+    <td>05/06/2025</td>
+    <td>20:12</td>
+    <td>70.87</td>
+</tr>
+<tr>
+    <td><a href="../races/sale-sizzler-1_summary.html">Sale sizzler 1*</a></td>
+    <td>19/06/2025</td>
+    <td>17:25</td>
+    <td>82.20</td>
 </tr>
 </table>
 <h2>Marathons</h2>

--- a/docs/athletes/steph-hughes_summary.html
+++ b/docs/athletes/steph-hughes_summary.html
@@ -18,8 +18,6 @@
     <li>Category position: 1 out of 5</li>
 </ul>
 <h2>Club races</h2>
-None
-<h2>5k races</h2>
 <table>
 <caption>* denotes race contributes to athlete's total score</caption>
 <tr>
@@ -29,16 +27,42 @@ None
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
-    <td><a href="../races/mid-cheshire-summer-5k_summary.html">Mid-Cheshire Summer 5k*</a></td>
+    <td><a href="../races/combined-5k-leaderboard_summary.html">Best 5k*</a></td>
     <td>29/08/2025</td>
     <td>23:48</td>
     <td>74.30</td>
     <td>19</td>
     <td>0</td>
     <td>19</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>19</td>
+    <td>0</td>
+    <td>19</td>
+</tr>
+</table>
+<h2>5k races</h2>
+<p>5k races are not scored individually. Instead, your fastest time contributes to the <a href="../races/combined-5k-leaderboard_summary.html">best 5k leaderboard</a>, which is then scored as if it were a single race.</p>
+<table>
+<caption>* denotes race contributes to athlete's total score</caption>
+<tr>
+    <th>Race</th>
+    <th>Date</th>
+    <th>Time</th>
+    <th>Age %</th>
+</tr>
+<tr>
+    <td><a href="../races/mid-cheshire-summer-5k_summary.html">Mid-Cheshire Summer 5k*</a></td>
+    <td>29/08/2025</td>
+    <td>23:48</td>
+    <td>74.30</td>
 </tr>
 </table>
 <h2>Marathons</h2>

--- a/docs/athletes/stephane-laffly_summary.html
+++ b/docs/athletes/stephane-laffly_summary.html
@@ -27,13 +27,22 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../races/altrincham-10k_summary.html">Altrincham 10k*</a></td>
     <td>07/09/2025</td>
     <td>41:49</td>
     <td>70.07</td>
+    <td>15</td>
+    <td>11</td>
+    <td>26</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
     <td>15</td>
     <td>11</td>
     <td>26</td>

--- a/docs/athletes/tim-greenald_summary.html
+++ b/docs/athletes/tim-greenald_summary.html
@@ -27,7 +27,7 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../races/wizard-5_summary.html">Wizard 5*</a></td>
@@ -47,8 +47,27 @@
     <td>25</td>
     <td>50</td>
 </tr>
+<tr>
+    <td><a href="../races/combined-5k-leaderboard_summary.html">Best 5k*</a></td>
+    <td>29/08/2025</td>
+    <td>17:00</td>
+    <td>88.14</td>
+    <td>17</td>
+    <td>25</td>
+    <td>42</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>66</td>
+    <td>75</td>
+    <td>141</td>
+</tr>
 </table>
 <h2>5k races</h2>
+<p>5k races are not scored individually. Instead, your fastest time contributes to the <a href="../races/combined-5k-leaderboard_summary.html">best 5k leaderboard</a>, which is then scored as if it were a single race.</p>
 <table>
 <caption>* denotes race contributes to athlete's total score</caption>
 <tr>
@@ -56,54 +75,36 @@
     <th>Date</th>
     <th>Time</th>
     <th>Age %</th>
-    <th>Time score</th>
-    <th>Age % score</th>
-    <th>Total score</th>
 </tr>
 <tr>
     <td><a href="../races/sale-sizzler-1_summary.html">Sale sizzler 1</a></td>
     <td>19/06/2025</td>
     <td>17:33</td>
     <td>85.38</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
 </tr>
 <tr>
     <td><a href="../races/sale-sizzler-2_summary.html">Sale sizzler 2</a></td>
     <td>04/07/2025</td>
     <td>17:13</td>
     <td>87.03</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
 </tr>
 <tr>
     <td><a href="../races/sale-sizzler-3_summary.html">Sale sizzler 3</a></td>
     <td>18/07/2025</td>
     <td>17:27</td>
     <td>85.86</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
 </tr>
 <tr>
     <td><a href="../races/sale-sizzler-4_summary.html">Sale sizzler 4</a></td>
     <td>31/07/2025</td>
     <td>17:25</td>
     <td>86.03</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
 </tr>
 <tr>
     <td><a href="../races/mid-cheshire-summer-5k_summary.html">Mid-Cheshire Summer 5k*</a></td>
     <td>29/08/2025</td>
     <td>17:00</td>
     <td>88.14</td>
-    <td>17</td>
-    <td>25</td>
-    <td>42</td>
 </tr>
 </table>
 <h2>Marathons</h2>

--- a/docs/athletes/tom-brown_summary.html
+++ b/docs/athletes/tom-brown_summary.html
@@ -18,8 +18,6 @@
     <li>Category position: 8 out of 21</li>
 </ul>
 <h2>Club races</h2>
-None
-<h2>5k races</h2>
 <table>
 <caption>* denotes race contributes to athlete's total score</caption>
 <tr>
@@ -29,16 +27,42 @@ None
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
-    <td><a href="../races/ellesmere-port-5k_summary.html">Ellesmere port 5k*</a></td>
+    <td><a href="../races/combined-5k-leaderboard_summary.html">Best 5k*</a></td>
     <td>13/08/2025</td>
     <td>16:59</td>
     <td>76.45</td>
     <td>18</td>
     <td>3</td>
     <td>21</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>18</td>
+    <td>3</td>
+    <td>21</td>
+</tr>
+</table>
+<h2>5k races</h2>
+<p>5k races are not scored individually. Instead, your fastest time contributes to the <a href="../races/combined-5k-leaderboard_summary.html">best 5k leaderboard</a>, which is then scored as if it were a single race.</p>
+<table>
+<caption>* denotes race contributes to athlete's total score</caption>
+<tr>
+    <th>Race</th>
+    <th>Date</th>
+    <th>Time</th>
+    <th>Age %</th>
+</tr>
+<tr>
+    <td><a href="../races/ellesmere-port-5k_summary.html">Ellesmere port 5k*</a></td>
+    <td>13/08/2025</td>
+    <td>16:59</td>
+    <td>76.45</td>
 </tr>
 </table>
 <h2>Marathons</h2>

--- a/docs/athletes/tom-moseley_summary.html
+++ b/docs/athletes/tom-moseley_summary.html
@@ -27,7 +27,7 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../races/manchester-half-marathon_summary.html">Manchester Half Marathon*</a></td>
@@ -38,8 +38,27 @@
     <td>22</td>
     <td>46</td>
 </tr>
+<tr>
+    <td><a href="../races/combined-5k-leaderboard_summary.html">Best 5k*</a></td>
+    <td>13/08/2025</td>
+    <td>17:16</td>
+    <td>81.66</td>
+    <td>16</td>
+    <td>14</td>
+    <td>30</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>40</td>
+    <td>36</td>
+    <td>76</td>
+</tr>
 </table>
 <h2>5k races</h2>
+<p>5k races are not scored individually. Instead, your fastest time contributes to the <a href="../races/combined-5k-leaderboard_summary.html">best 5k leaderboard</a>, which is then scored as if it were a single race.</p>
 <table>
 <caption>* denotes race contributes to athlete's total score</caption>
 <tr>
@@ -47,36 +66,24 @@
     <th>Date</th>
     <th>Time</th>
     <th>Age %</th>
-    <th>Time score</th>
-    <th>Age % score</th>
-    <th>Total score</th>
 </tr>
 <tr>
     <td><a href="../races/sale-sizzler-1_summary.html">Sale sizzler 1</a></td>
     <td>19/06/2025</td>
     <td>18:08</td>
     <td>77.76</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
 </tr>
 <tr>
     <td><a href="../races/sale-sizzler-2_summary.html">Sale sizzler 2</a></td>
     <td>04/07/2025</td>
     <td>17:33</td>
     <td>80.34</td>
-    <td>0</td>
-    <td>0</td>
-    <td>0</td>
 </tr>
 <tr>
     <td><a href="../races/ellesmere-port-5k_summary.html">Ellesmere port 5k*</a></td>
     <td>13/08/2025</td>
     <td>17:16</td>
     <td>81.66</td>
-    <td>16</td>
-    <td>14</td>
-    <td>30</td>
 </tr>
 </table>
 <h2>Marathons</h2>

--- a/docs/athletes/tom-sullivan_summary.html
+++ b/docs/athletes/tom-sullivan_summary.html
@@ -27,7 +27,7 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../races/wilmslow-summer-10k_summary.html">Wilmslow Summer 10k*</a></td>
@@ -46,6 +46,15 @@
     <td>25</td>
     <td>23</td>
     <td>48</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>50</td>
+    <td>47</td>
+    <td>97</td>
 </tr>
 </table>
 <h2>5k races</h2>

--- a/docs/athletes/vicki-perry_summary.html
+++ b/docs/athletes/vicki-perry_summary.html
@@ -18,10 +18,6 @@
     <li>Category position: 1 out of 2</li>
 </ul>
 <h2>Club races</h2>
-None
-<h2>5k races</h2>
-None
-<h2>Marathons</h2>
 <table>
 <caption>* denotes race contributes to athlete's total score</caption>
 <tr>
@@ -31,16 +27,44 @@ None
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
-    <td><a href="../races/chester-marathon_summary.html">Chester Marathon*</a></td>
+    <td><a href="../races/combined-marathon-leaderboard_summary.html">Marathon*</a></td>
     <td>05/10/2025</td>
     <td>3:43:57</td>
     <td>87.30</td>
     <td>25</td>
     <td>25</td>
     <td>50</td>
+</tr>
+<tr>
+    <td><b>Totals</></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td>25</td>
+    <td>25</td>
+    <td>50</td>
+</tr>
+</table>
+<h2>5k races</h2>
+None
+<h2>Marathons</h2>
+<p>Marathons are not scored individually. Instead, your fastest time contributes to the <a href="../races/combined-marathon-leaderboard_summary.html">best marathon leaderboard</a>, which is then scored as if it were a single race.</p>
+<table>
+<caption>* denotes race contributes to athlete's total score</caption>
+<tr>
+    <th>Race</th>
+    <th>Date</th>
+    <th>Time</th>
+    <th>Age %</th>
+</tr>
+<tr>
+    <td><a href="../races/chester-marathon_summary.html">Chester Marathon*</a></td>
+    <td>05/10/2025</td>
+    <td>3:43:57</td>
+    <td>87.30</td>
 </tr>
 </table>
 <p><a href="../index.html"><br><br>Home</a></p>

--- a/docs/races/altrincham-10k_summary.html
+++ b/docs/races/altrincham-10k_summary.html
@@ -23,7 +23,7 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../athletes/michael-whitham_summary.html">Michael Whitham*</a></td>

--- a/docs/races/combined-5k-leaderboard_summary.html
+++ b/docs/races/combined-5k-leaderboard_summary.html
@@ -22,7 +22,7 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../athletes/luke-hornby_summary.html">Luke Hornby*</a></td>

--- a/docs/races/combined-marathon-leaderboard_summary.html
+++ b/docs/races/combined-marathon-leaderboard_summary.html
@@ -22,7 +22,7 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../athletes/vicki-perry_summary.html">Vicki Perry*</a></td>

--- a/docs/races/manchester-half-marathon_summary.html
+++ b/docs/races/manchester-half-marathon_summary.html
@@ -23,7 +23,7 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../athletes/tom-sullivan_summary.html">Tom Sullivan*</a></td>

--- a/docs/races/monton-5_summary.html
+++ b/docs/races/monton-5_summary.html
@@ -23,7 +23,7 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../athletes/tim-greenald_summary.html">Tim Greenald*</a></td>

--- a/docs/races/wilmslow-summer-10k_summary.html
+++ b/docs/races/wilmslow-summer-10k_summary.html
@@ -23,7 +23,7 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../athletes/tom-sullivan_summary.html">Tom Sullivan*</a></td>

--- a/docs/races/wizard-5_summary.html
+++ b/docs/races/wizard-5_summary.html
@@ -23,7 +23,7 @@
     <th>Age %</th>
     <th>Time score</th>
     <th>Age % score</th>
-    <th>Total score</th>
+    <th>Race score</th>
 </tr>
 <tr>
     <td><a href="../athletes/michael-berks_summary.html">Michael Berks*</a></td>

--- a/src/athlete_page.py
+++ b/src/athlete_page.py
@@ -1,3 +1,4 @@
+from copy import copy
 from pathlib import Path
 from typing import Collection
 
@@ -11,7 +12,14 @@ from src.utils import date_to_str, secs_to_time_str
 class AthletePage:
 
     @staticmethod
-    def print_athlete_page(athlete:Athlete, all_athletes:dict[str,Athlete], all_races:dict[str,Race]):
+    def print_athlete_page(
+        athlete:Athlete,
+        all_athletes:dict[str,Athlete],
+        all_races:dict[str,Race],
+        combined_5k_page:Path,
+        combined_marathon_page:Path):
+        
+        
         def scored_more(other_athlete:Athlete):
             return other_athlete.total_score > athlete.total_score
         
@@ -26,16 +34,35 @@ class AthletePage:
             rank = sum(scored_more(a) for a in other_athletes)+1
             return f'{rank} out of {total}'
         
-        def print_race_headers(file_id):
+        def print_race_headers(is_club:bool, file_id):
             caption = "* denotes race contributes to athlete's total score"
-            hp.html_start_table(['Race', 'Date', 'Time', 'Age %', 'Time score', 'Age % score', 'Total score'],
-                                file_id, caption=caption)
+            headers = ['Race', 'Date', 'Time', 'Age %']
+            if is_club:
+                headers += ['Time score', 'Age % score', 'Race score']
+            hp.html_start_table(headers, file_id, caption=caption)
 
         def print_race_summary(race_entry:RaceEntry, file_id):
             race = all_races[race_entry.race_name]
             counter = '*' if race_entry in athlete.counting_races else ''
             col_values = [
                 hp.html_link(race_entry.race_name+counter, Path('..')/race.summary_page),
+                date_to_str(race_entry.race_date),
+                secs_to_time_str(race_entry.time),
+                f'{race_entry.age_pct:3.2f}',         
+            ]
+            if race_entry.is_club:
+                col_values += [
+                    race_entry.time_score,
+                race_entry.age_pct_score,
+                race_entry.total_score
+                ]
+            hp.html_table_row(col_values, file_id)
+
+        def print_combined_race_summary(race_entry:RaceEntry, title:str, link:Path, file_id):
+            
+            counter = '*' if race_entry in athlete.counting_races else ''
+            col_values = [
+                hp.html_link(title+counter, Path('..')/link),
                 date_to_str(race_entry.race_date),
                 secs_to_time_str(race_entry.time),
                 f'{race_entry.age_pct:3.2f}',
@@ -46,11 +73,33 @@ class AthletePage:
             hp.html_table_row(col_values, file_id)
             
         
-        def print_race_list(races:list[RaceEntry], file_id):
-            if races:
-                print_race_headers(file_id)
+        def print_race_list(is_club_table:bool, races:list[RaceEntry], file_id):
+            n_races = len(races)
+            if is_club_table:
+                n_races += bool(athlete.best_5k.race_name) + bool(athlete.best_marathon.race_name)
+
+            if n_races:    
+                print_race_headers(is_club_table, file_id)
                 for race in races:
                     print_race_summary(race, file_id)
+
+                if is_club_table:
+                    if athlete.best_5k.race_name:
+                        print_combined_race_summary(athlete.best_5k, 'Best 5k', combined_5k_page, file_id)
+                    if athlete.best_marathon.race_name:
+                        print_combined_race_summary(athlete.best_marathon, 'Marathon', combined_marathon_page, file_id)
+
+                    totals_cols = [
+                        '<b>Totals</>',
+                    '',
+                    '',
+                    '',
+                    athlete.time_score,
+                    athlete.age_pct_score,
+                    athlete.total_score
+                    ]
+                    hp.html_table_row(totals_cols, file_id)
+
                 hp.html_end_table(file=file_id)
             else:
                 print('None', file=file_id)
@@ -71,12 +120,28 @@ class AthletePage:
             f'Category position: {rank_str(matched_category_athletes)}'], file=file_id)
 
             hp.html_h('Club races', 2, file=file_id)
-            print_race_list(athlete.club_races, file_id)
+            print_race_list(True, athlete.club_races, file_id)
 
             hp.html_h('5k races', 2, file=file_id)
-            print_race_list(athlete._5k_races, file_id)
+            if athlete._5k_races:
+                hp.html_p(
+                    '5k races are not scored individually. '
+                    'Instead, your fastest time contributes to the ' +
+                    hp.html_link('best 5k leaderboard', Path('..')/combined_5k_page) +
+                    ', which is then scored as if it were '
+                    'a single race.', file_id
+                    )
+            print_race_list(False, athlete._5k_races, file_id)
 
             hp.html_h('Marathons', 2, file=file_id)
-            print_race_list(athlete.marathons, file_id)
+            if athlete.marathons:
+                hp.html_p(
+                    'Marathons are not scored individually. '
+                    'Instead, your fastest time contributes to the ' +
+                    hp.html_link('best marathon leaderboard', Path('..')/combined_marathon_page) +
+                    ', which is then scored as if it were '
+                    'a single race.', file_id
+                    )
+            print_race_list(False, athlete.marathons, file_id)
             hp.html_p(hp.html_link('<br><br>Home', Path('../index.html')), file=file_id)
             hp.html_footer(file_id)

--- a/src/race_page.py
+++ b/src/race_page.py
@@ -15,7 +15,7 @@ class RacePage:
         def print_race_headers(file_id):
             headers = ['Athlete', 'Gender', 'Category', 'Time', 'Age %']
             if not (race.is_5k or race.is_marathon):
-                headers += ['Time score', 'Age % score', 'Total score']
+                headers += ['Time score', 'Age % score', 'Race score']
             caption = "* denotes race contributes to athlete's total score"
             hp.html_start_table(
                 headers, file=file_id, caption=caption)
@@ -66,7 +66,7 @@ class RacePage:
         def print_race_headers(file_id):
             caption = "* denotes race contributes to athlete's total score"
             hp.html_start_table(
-                ['Athlete', 'Gender', 'Category', 'Race', 'Date', 'Time', 'Age %', 'Time score', 'Age % score', 'Total score'],
+                ['Athlete', 'Gender', 'Category', 'Race', 'Date', 'Time', 'Age %', 'Time score', 'Age % score', 'Race score'],
                 file=file_id, caption=caption)
 
         def print_race_summary(race_entry:RaceEntry, file_id):

--- a/src/race_processor.py
+++ b/src/race_processor.py
@@ -91,7 +91,9 @@ class RaceProcessor:
     def print_tables(self):
         for athlete in self.athletes.values():
             if athlete.total_score:                
-                AthletePage.print_athlete_page(athlete, self.athletes, self.races)
+                AthletePage.print_athlete_page(
+                    athlete, self.athletes, self.races,
+                    self.combined_5k.summary_page, self.combined_marathon.summary_page)
 
         for race in self.races.values():
             RacePage.print_race_page(race, self.athletes)


### PR DESCRIPTION
- Removes scores from individual 5k tables on athlete pages
- Adds 5k and marathon leader boards to the club races table (if athlete has completed a 5k/marathon)
- Adds explainer under 5k and marathon section headers (if athlete has completed a 5k/marathon)
- Add totals row to scores table
- Renames 'total score' to 'race score' for individual races, to separate from an athlete's overall total score
- Applies the same 'total score' to 'race score' change for tables on race pages